### PR TITLE
CAF-1750 / CAF-1860 - 

### DIFF
--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/PropertyValidatingProcessor.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/PropertyValidatingProcessor.java
@@ -146,8 +146,9 @@ public abstract class PropertyValidatingProcessor<TResult, TInput, TExpected> ex
      * @param message  the message
      * @return the expectation map
      */
-    protected abstract Map<String, Object> getFailedExpectationMap(TestItem<TInput, TExpected> testItem, TaskMessage message);
-
+    protected  Map<String, Object> getFailedExpectationMap(TestItem<TInput, TExpected> testItem, TaskMessage message){
+        return null;
+    }
     /**
      * Gets validated object.
      *


### PR DESCRIPTION
return null failed expectation map, so it doesn't have to be implemented by other workers, this work will continue on CAF-1860.