### PR TITLE
CAF-1860: Bug Fix for worker-extract 

### DIFF
--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/AbstractResultProcessor.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/AbstractResultProcessor.java
@@ -83,6 +83,9 @@ public abstract class AbstractResultProcessor<TResult, TInput, TExpected> implem
      * @throws CodecException the codec exception
      */
     protected TResult deserializeMessage(TaskMessage message, Class<TResult> resultClass) throws CodecException {
+        if (message.getTaskStatus() != TaskStatus.RESULT_SUCCESS && message.getTaskStatus() != TaskStatus.RESULT_FAILURE) {
+            throw new AssertionError("Task status was failure.");
+        }
         TResult workerResult = codec.deserialise(message.getTaskData(), resultClass);
         return workerResult;
     }

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/AbstractResultProcessor.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/AbstractResultProcessor.java
@@ -61,15 +61,6 @@ public abstract class AbstractResultProcessor<TResult, TInput, TExpected> implem
 
     @Override
     public boolean process(TestItem testItem, TaskMessage resultMessage) throws Exception {
-        if (resultMessage.getTaskStatus() != TaskStatus.RESULT_SUCCESS && resultMessage.getTaskStatus() != TaskStatus.RESULT_FAILURE){
-            HashMap<String, String> mapResult = new HashMap();
-            mapResult.put("TaskStatus", resultMessage.getTaskStatus().toString());
-
-            Map<String, Object> map = new LinkedHashMap<>();
-            map.put("taskResultsFailure", mapResult);
-
-            return processFailedWorkerResult(testItem, resultMessage, map);
-        }
         TResult workerResult = deserializeMessage(resultMessage, resultClass);
         return processWorkerResult(testItem, resultMessage, workerResult);
     }


### PR DESCRIPTION
CAF-1860: Bug Fix for worker-extract. "Could not locate result in pre-defined testcase", added validation before message is deserialised.