### PR TITLE
Update to use the 1.0.1-SNAPSHOT caf-parent version, so that worker-f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/worker-framework/tests/pom.xml
+++ b/worker-framework/tests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
…ramework build can correctly be deployed using the RE_BUILD_TYPE environment option.