### PR TITLE
CAF-1751: Tracking details for INVALID_TASK messages need consideration.

### DIFF
--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -129,27 +129,30 @@ class WorkerTaskImpl implements WorkerTask
         ensureSingleResponse();
 
         LOG.error("Task data is invalid for {}, returning status {}",
-            taskMessage.getTaskId(), TaskStatus.INVALID_TASK, invalidTaskException);
+                taskMessage.getTaskId(), TaskStatus.INVALID_TASK, invalidTaskException);
 
-        final String taskId =
-            MoreObjects.firstNonNull(taskMessage.getTaskId(), "");
-        final String taskClassifier =
-            MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), "");
-        final int taskApiVersion = taskMessage.getTaskApiVersion();
         final String invalidTaskExceptionMessage = invalidTaskException.getMessage();
         final byte[] taskData =
                 invalidTaskExceptionMessage == null ?
                         new byte[] {} : invalidTaskExceptionMessage.getBytes(StandardCharsets.UTF_8);
-        final TaskStatus taskStatus = TaskStatus.INVALID_TASK;
+
         final Map<String, byte[]> context = MoreObjects.firstNonNull(
-            taskMessage.getContext(),
-            Collections.<String, byte[]>emptyMap());
+                taskMessage.getContext(),
+                Collections.<String, byte[]>emptyMap());
 
         final TaskMessage invalidResponse = new TaskMessage(
-            taskId, taskClassifier, taskApiVersion, taskData, taskStatus, context);
+                MoreObjects.firstNonNull(taskMessage.getTaskId(), ""),
+                MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), ""),
+                taskMessage.getTaskApiVersion(),
+                taskData,
+                TaskStatus.INVALID_TASK,
+                context,
+                workerFactory.getInvalidTaskQueue(),
+                taskMessage.getTracking(),
+                new TaskSourceInfo(getWorkerName(MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), "")), getWorkerVersion()));
 
         workerCallback.complete(
-            messageId, workerFactory.getInvalidTaskQueue(), invalidResponse);
+                messageId, workerFactory.getInvalidTaskQueue(), invalidResponse);
     }
 
     public Worker createWorker()

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -131,6 +131,8 @@ class WorkerTaskImpl implements WorkerTask
         LOG.error("Task data is invalid for {}, returning status {}",
                 taskMessage.getTaskId(), TaskStatus.INVALID_TASK, invalidTaskException);
 
+        final String taskClassifier = MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), "");
+
         final String invalidTaskExceptionMessage = invalidTaskException.getMessage();
         final byte[] taskData =
                 invalidTaskExceptionMessage == null ?
@@ -142,14 +144,14 @@ class WorkerTaskImpl implements WorkerTask
 
         final TaskMessage invalidResponse = new TaskMessage(
                 MoreObjects.firstNonNull(taskMessage.getTaskId(), ""),
-                MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), ""),
+                taskClassifier,
                 taskMessage.getTaskApiVersion(),
                 taskData,
                 TaskStatus.INVALID_TASK,
                 context,
                 workerFactory.getInvalidTaskQueue(),
                 taskMessage.getTracking(),
-                new TaskSourceInfo(getWorkerName(MoreObjects.firstNonNull(taskMessage.getTaskClassifier(), "")), getWorkerVersion()));
+                new TaskSourceInfo(getWorkerName(taskClassifier), getWorkerVersion()));
 
         workerCallback.complete(
                 messageId, workerFactory.getInvalidTaskQueue(), invalidResponse);


### PR DESCRIPTION
Changes required to include tracking details for INVALID_TASK messages. Without these the job tracking worker is not able to report on the reasons for the InvalidTaskException.
To be considered with https://github.hpe.com/caf/job-service/pull/12.