### PR TITLE
CAF-2096 

### DIFF
--- a/worker-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/worker-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -22,6 +22,7 @@
     <requiredProperties>
         <requiredProperty key="workerName" />
         <requiredProperty key="artifactId" />
+        <requiredProperty key="archetypeVersion" />
     </requiredProperties>
 
     <modules>

--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
@@ -32,8 +32,6 @@
 
     <!-- Properties for the worker. -->
     <properties>
-        <caf.worker-framework.version>1.2.0-SNAPSHOT</caf.worker-framework.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <docker.maven.version>0.13.6</docker.maven.version>
@@ -43,8 +41,6 @@
         <test.configs>${project.basedir}/test-configs</test.configs>
         <maven.failsafe.version>2.19</maven.failsafe.version>
         <maven.compiler.version>3.3</maven.compiler.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <!--
@@ -56,7 +52,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-framework</artifactId>
-                <version>${caf.worker-framework.version}</version>
+                <version>${workerFrameworkVersion}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -234,7 +230,7 @@
                                 <maintainer>conal.smith@hpe.com</maintainer>
                                 <from>java:8</from>
                                 <labels>
-                                    <caf.worker-framework.version>${caf.worker-framework.version}</caf.worker-framework.version>
+                                    <caf.worker-framework.version>${workerFrameworkVersion}</caf.worker-framework.version>
                                 </labels>
                                 <!-- The entry point will be the worker.sh executable. -->
                                 <entryPoint>

--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-shared/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-shared/pom.xml
@@ -27,20 +27,14 @@
         <groupId>${groupId}</groupId>
         <artifactId>${rootArtifactId}-aggregator</artifactId>
         <version>${version}</version>
-    </parent>    
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+    </parent>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-framework</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>${workerFrameworkVersion}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-testing/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-testing/pom.xml
@@ -29,13 +29,7 @@
         <groupId>${groupId}</groupId>
         <artifactId>${rootArtifactId}-aggregator</artifactId>
         <version>${version}</version>
-    </parent>    
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+    </parent>
 
     <dependencies>
         <dependency>
@@ -46,7 +40,7 @@
         <dependency>
             <groupId>com.github.workerframework</groupId>
             <artifactId>worker-testing-integration</artifactId>
-            <version>1.2.0-SNAPSHOT</version>
+            <version>${workerFrameworkVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -29,18 +29,12 @@
         <version>${version}</version>
     </parent>    
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-framework</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>${workerFrameworkVersion}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/worker-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,13 @@
     <artifactId>${artifactId}-aggregator</artifactId>
     <version>${version}</version>
     <packaging>pom</packaging>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <workerFrameworkVersion>${archetypeVersion}</workerFrameworkVersion>
+    </properties>
 
     <modules>
         <module>${artifactId}-shared</module>

--- a/worker-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/worker-archetype/src/test/resources/projects/basic/archetype.properties
@@ -4,3 +4,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.hpe.caf.it.worker
 workerName=ExampleWorker
 artifactId=worker-example
+archetypeVersion=1.5.0-SNAPSHOT


### PR DESCRIPTION
Updated the Worker-Archetype project in the same manner as the Worker-Document-Archetype was updated to address the same issue.

This works because archetypeVersion=<version> in the command `mvn archetype:generate -DarchetypeVersion=1.4.0 -DarchetypeArtifactId=worker-archetype -DarchetypeGroupId=com.github.workerframework`, are in sync as the same version.