### PR TITLE
CAF-2306: Add custom validator support

### DIFF
--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/configuration/ValidationSettings.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/configuration/ValidationSettings.java
@@ -57,8 +57,8 @@ public class ValidationSettings {
             return this;
         }
 
-        public ValidationSettingsBuilder customValidationProperties(CustomPropertyValidator... customPropertyValidators) {
-            settings.customValidationProperties = Arrays.asList(customPropertyValidators);
+        public ValidationSettingsBuilder customValidators(CustomPropertyValidator... customPropertyValidators) {
+            settings.customValidators = Arrays.asList(customPropertyValidators);
             return this;
         }
 
@@ -72,7 +72,7 @@ public class ValidationSettings {
     private Set<String> ignoredProperties = new HashSet<>();
     private Set<String> referencedDataProperties = new HashSet<>();
     private Set<String> base64Properties = new HashSet<>();
-    private List<CustomPropertyValidator> customValidationProperties = new ArrayList<>();
+    private List<CustomPropertyValidator> customValidators = new ArrayList<>();
 
     public static ValidationSettingsBuilder configure() {
         return new ValidationSettingsBuilder(new ValidationSettings());
@@ -117,7 +117,7 @@ public class ValidationSettings {
         return base64Properties;
     }
 
-    public List<CustomPropertyValidator> getCustomValidationProperties() {
-        return customValidationProperties;
+    public List<CustomPropertyValidator> getCustomValidators() {
+        return customValidators;
     }
 }

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/configuration/ValidationSettings.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/configuration/ValidationSettings.java
@@ -15,9 +15,9 @@
  */
 package com.hpe.caf.worker.testing.configuration;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import com.hpe.caf.worker.testing.validation.CustomPropertyValidator;
+
+import java.util.*;
 
 /**
  * Created by ploch on 07/12/2015.
@@ -57,6 +57,11 @@ public class ValidationSettings {
             return this;
         }
 
+        public ValidationSettingsBuilder customValidationProperties(CustomPropertyValidator... customPropertyValidators) {
+            settings.customValidationProperties = Arrays.asList(customPropertyValidators);
+            return this;
+        }
+
         public ValidationSettings build(){
             return settings;
         }
@@ -67,6 +72,7 @@ public class ValidationSettings {
     private Set<String> ignoredProperties = new HashSet<>();
     private Set<String> referencedDataProperties = new HashSet<>();
     private Set<String> base64Properties = new HashSet<>();
+    private List<CustomPropertyValidator> customValidationProperties = new ArrayList<>();
 
     public static ValidationSettingsBuilder configure() {
         return new ValidationSettingsBuilder(new ValidationSettings());
@@ -109,5 +115,9 @@ public class ValidationSettings {
      */
     public Set<String> getBase64Properties() {
         return base64Properties;
+    }
+
+    public List<CustomPropertyValidator> getCustomValidationProperties() {
+        return customValidationProperties;
     }
 }

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidator.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidator.java
@@ -19,5 +19,18 @@ package com.hpe.caf.worker.testing.validation;
  * Base for single-property validators that apply custom validation.
  */
 public abstract class CustomPropertyValidator extends PropertyValidator {
+    /**
+     * Determines whether this validator can validate properties with the specified name whose type matches that indicated by the
+     * type of the sourcePropertyValue and validatorPropertyValue parameters.
+     * @param propertyName if not null then this method verifies whether the validator can validate properties with this property
+     *                     name whose type matches the type of the sourcePropertyValue and validatorPropertyValue arguments.
+     *                     If propertyName is null then this method indicates whether this validator can validate properties whose
+     *                     type matches the type of the sourcePropertyValue and validatorPropertyValue arguments, regardless of their
+     *                     property name; if the validator insists on including a property name check when validating then this method
+     *                     will return false if supplied with a null propertyName argument.
+     * @param sourcePropertyValue an exemplar of the type of value to be validated
+     * @param validatorPropertyValue an exemplar of the type of value against which property values will be validated
+     * @return whether the validator can validate properties with the specified name (if supplied) and value types
+     */
     public abstract boolean canValidate(String propertyName, Object sourcePropertyValue, Object validatorPropertyValue);
 }

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidator.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.testing.validation;
+
+/**
+ * Base for single-property validators that apply custom validation.
+ */
+public abstract class CustomPropertyValidator extends PropertyValidator {
+    public abstract boolean canValidate(String propertyName, Object sourcePropertyValue, Object validatorPropertyValue);
+}

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/ValidatorFactory.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/ValidatorFactory.java
@@ -67,6 +67,11 @@ public class ValidatorFactory {
                 return new Base64PropertyValidator();
             }
         }
+        for (CustomPropertyValidator customPropertyValidator : validationSettings.getCustomValidationProperties()) {
+            if (customPropertyValidator.canValidate(propertyName, sourcePropertyValue, validatorPropertyValue)) {
+                return customPropertyValidator;
+            }
+        }
         if (sourcePropertyValue instanceof Map && validatorPropertyValue instanceof Map) {
             return new PropertyMapValidator(this);
         }

--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/ValidatorFactory.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/validation/ValidatorFactory.java
@@ -67,7 +67,7 @@ public class ValidatorFactory {
                 return new Base64PropertyValidator();
             }
         }
-        for (CustomPropertyValidator customPropertyValidator : validationSettings.getCustomValidationProperties()) {
+        for (final CustomPropertyValidator customPropertyValidator : validationSettings.getCustomValidators()) {
             if (customPropertyValidator.canValidate(propertyName, sourcePropertyValue, validatorPropertyValue)) {
                 return customPropertyValidator;
             }

--- a/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
+++ b/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
@@ -37,36 +37,54 @@ public class CustomPropertyValidatorTest {
         final String STRING_PROP_1 = "stringProp1";
 
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2), new CustomIntPropertyValidator(), new CustomStringPropertyValidator())
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2),
+                        new CustomIntPropertyValidator(),
+                        new CustomStringPropertyValidator())
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator namedIntProp1Validator = validatorFactory.create(INT_PROP_1, 42, 42);
-        assertTrue(namedIntProp1Validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertTrue(namedIntProp1Validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of " +
+                        "the property being validated");
         assertTrue(namedIntProp1Validator.isValid(42, 42));
 
         final PropertyValidator namedIntProp2Validator = validatorFactory.create(INT_PROP_2, 999, 999);
-        assertTrue(namedIntProp2Validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertTrue(namedIntProp2Validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of " +
+                        "the property being validated");
         assertTrue(namedIntProp2Validator.isValid(999, 999));
 
-        assertEquals(namedIntProp1Validator, namedIntProp2Validator, "Expected the same validator instance to be used for both named int property validations as we've configured a CustomIntPropertyValidator that accepts the names of both properties being validated");
+        assertEquals(namedIntProp1Validator, namedIntProp2Validator,
+                "Expected the same validator instance to be used for both named int property validations as we've configured a " +
+                        "CustomIntPropertyValidator that accepts the names of both properties being validated");
 
         final PropertyValidator unnamedIntPropValidator = validatorFactory.create(null, 42, 42);
-        assertTrue(unnamedIntPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that ignores the name of the property being validated");
+        assertTrue(unnamedIntPropValidator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that ignores the name of " +
+                        "the property being validated");
         assertTrue(unnamedIntPropValidator.isValid(42, 42));
 
-        assertNotEquals(namedIntProp1Validator, unnamedIntPropValidator, "Expected different validator instances for named and unnamed int property validations");
+        assertNotEquals(namedIntProp1Validator, unnamedIntPropValidator,
+                "Expected different validator instances for named and unnamed int property validations");
 
         final PropertyValidator namedStringPropValidator = validatorFactory.create(STRING_PROP_1, "hello world", "hello world");
-        assertTrue(namedStringPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of the property being validated");
+        assertTrue(namedStringPropValidator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of " +
+                        "the property being validated");
         assertTrue(namedStringPropValidator.isValid("hello world", "hello world"));
 
         final PropertyValidator unnamedStringPropValidator = validatorFactory.create(null, "go away", "go away");
-        assertTrue(unnamedStringPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of the property being validated");
+        assertTrue(unnamedStringPropValidator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of " +
+                        "the property being validated");
         assertTrue(unnamedStringPropValidator.isValid("go away", "go away"));
 
-        assertEquals(namedStringPropValidator, unnamedStringPropValidator, "Expected the same validator instance to be used for both named and unnamed string property validations as we've configured a CustomStringPropertyValidator that ignores the names of the property being validated");
+        assertEquals(namedStringPropValidator, unnamedStringPropValidator,
+                "Expected the same validator instance to be used for both named and unnamed string property validations as we've " +
+                        "configured a CustomStringPropertyValidator that ignores the names of the property being validated");
     }
 
     @Test
@@ -77,10 +95,14 @@ public class CustomPropertyValidatorTest {
                 .customValidators(new CustomIntPropertyValidator(INT_PROP_1))
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator validator = validatorFactory.create(INT_PROP_1, 42, 53);
-        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator for named int property validation despite specifying differing values when creating the validator, as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertTrue(validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator for named int property validation despite specifying differing values when " +
+                        "creating the validator, as we've configured a CustomIntPropertyValidator that accepts the name of the " +
+                        "property being validated");
         assertFalse(validator.isValid(42, 53));
     }
 
@@ -90,10 +112,14 @@ public class CustomPropertyValidatorTest {
                 .customValidators(new CustomIntPropertyValidator())
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator validator = validatorFactory.create(null, 42, 53);
-        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator for unnamed int property validation despite specifying differing values when creating the validator, as we've configured a CustomIntPropertyValidator that ignores the name of the property being validated");
+        assertTrue(validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator for unnamed int property validation despite specifying differing values when " +
+                        "creating the validator, as we've configured a CustomIntPropertyValidator that ignores the name of the " +
+                        "property being validated");
         assertFalse(validator.isValid(42, 53));
     }
 
@@ -107,10 +133,13 @@ public class CustomPropertyValidatorTest {
                 .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2))
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator validator = validatorFactory.create(INT_PROP_3, 42, 42);
-        assertFalse(validator instanceof CustomPropertyValidator, "Did not expect a CustomPropertyValidator as the configured CustomPropertyValidator does not accept the named property being validated");
+        assertFalse(validator instanceof CustomPropertyValidator,
+                "Did not expect a CustomPropertyValidator as the configured CustomPropertyValidator does not accept the named " +
+                        "property being validated");
         assertTrue(validator.isValid(42, 42));
     }
 
@@ -122,11 +151,15 @@ public class CustomPropertyValidatorTest {
                 .customValidators(new CustomIntPropertyValidator(INT_PROP_1))
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator validator = validatorFactory.create(INT_PROP_1, 42, 42);
-        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
-        assertFalse(validator.isValid("not-an-int", "not-an-int"), "Expected validation failure as the validator is testing types that it was not created to validate");
+        assertTrue(validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of " +
+                        "the property being validated");
+        assertFalse(validator.isValid("not-an-int", "not-an-int"),
+                "Expected validation failure as the validator is testing types that it was not created to validate");
     }
 
     @Test
@@ -136,18 +169,29 @@ public class CustomPropertyValidatorTest {
         final String INT_PROP_3 = "intProp3";
 
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2), new CustomIntPropertyValidator(INT_PROP_2, INT_PROP_3))
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2),
+                        new CustomIntPropertyValidator(INT_PROP_2, INT_PROP_3))
                 .build();
 
-        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+        final ValidatorFactory validatorFactory =
+                new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
         final PropertyValidator validator = validatorFactory.create(INT_PROP_2, 42, 42);
-        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
-        assertTrue(validator instanceof CustomIntPropertyValidator, "Expected the validator to be specifically a CustomIntPropertyValidator");
+        assertTrue(validator instanceof CustomPropertyValidator,
+                "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of " +
+                        "the property being validated");
+        assertTrue(validator instanceof CustomIntPropertyValidator,
+                "Expected the validator to be specifically a CustomIntPropertyValidator");
 
         CustomIntPropertyValidator customIntValidator = (CustomIntPropertyValidator)validator;
-        assertEquals(customIntValidator.getRecognizedPropertyNames().size(), 2, "Expected to use the configured CustomIntPropertyValidator that recognizes 2 property names");
-        assertTrue(customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_1) && customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_2), "Expected to use the configured CustomIntPropertyValidator that recognizes the property names \"" + INT_PROP_1 + "\" and \"" + INT_PROP_2 + "\"");
+        assertEquals(customIntValidator.getRecognizedPropertyNames().size(), 2,
+                "Expected to use the configured CustomIntPropertyValidator that recognizes 2 property names");
+        assertTrue(customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_1) &&
+                customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_2),
+                "Expected to use the configured CustomIntPropertyValidator that recognizes the property names \"" +
+                        INT_PROP_1 +
+                        "\" and \"" +
+                        INT_PROP_2 + "\"");
         assertTrue(validator.isValid(42, 42));
     }
 

--- a/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
+++ b/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.testing.validation;
+
+import com.google.common.base.Strings;
+import com.hpe.caf.worker.testing.TestConfiguration;
+import com.hpe.caf.worker.testing.configuration.ValidationSettings;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class CustomPropertyValidatorTest {
+
+    /**
+     * Tests "happy-path" custom validation.
+     */
+    @Test
+    public void testCustomPropertyValidation() {
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidationProperties(new CustomIntByNamePropertyValidator("intProp1", "intProp2"), new CustomStringPropertyValidator())
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator namedIntProp1Validator = validatorFactory.create("intProp1", 42, 42);
+        assertTrue(namedIntProp1Validator.isValid(42, 42));
+        final PropertyValidator namedIntProp2Validator = validatorFactory.create("intProp2", 999, 999);
+        assertTrue(namedIntProp2Validator.isValid(999, 999));
+        assertEquals(namedIntProp1Validator, namedIntProp2Validator, "Expected the same validator to be used for both unnamed int property validations");
+
+        final PropertyValidator unnamedIntPropValidator = validatorFactory.create(null, 42, 42);
+        assertTrue(unnamedIntPropValidator.isValid(42, 42));
+        assertNotEquals(namedIntProp1Validator, unnamedIntPropValidator, "Expected different validators to be used for named and unnamed int property validations");
+
+        final PropertyValidator stringProp1Validator = validatorFactory.create("stringProp1", "hello world", "hello world");
+        assertTrue(stringProp1Validator.isValid("hello world", "hello world"));
+        final PropertyValidator stringProp2Validator = validatorFactory.create(null, "go away", "go away");
+        assertTrue(stringProp2Validator.isValid("go away", "go away"));
+        assertEquals(stringProp1Validator, stringProp2Validator, "Expected the same validator to be used for named and unnamed string property validations");
+    }
+
+
+    private static class CustomIntByNamePropertyValidator extends CustomPropertyValidator {
+        private Collection<String> recognizedPropertyNames = new ArrayList<>();
+
+        public CustomIntByNamePropertyValidator(final String... recognizedPropertyNames) {
+            this.recognizedPropertyNames = new ArrayList<>(Arrays.asList(recognizedPropertyNames));
+        }
+
+        @Override
+        public boolean canValidate(String propertyName, Object sourcePropertyValue, Object validatorPropertyValue) {
+            return !Strings.isNullOrEmpty(propertyName) &&
+                    recognizedPropertyNames.contains(propertyName) &&
+                    sourcePropertyValue instanceof Integer &&
+                    validatorPropertyValue instanceof Integer;
+        }
+
+        @Override
+        protected boolean isValid(Object testedPropertyValue, Object validatorPropertyValue) {
+            return testedPropertyValue instanceof Integer &&
+                    validatorPropertyValue instanceof Integer &&
+                    testedPropertyValue.equals(validatorPropertyValue);
+        }
+    }
+
+
+    private static class CustomStringPropertyValidator extends CustomPropertyValidator {
+        @Override
+        public boolean canValidate(String propertyName, Object sourcePropertyValue, Object validatorPropertyValue) {
+            return sourcePropertyValue instanceof String &&
+                    validatorPropertyValue instanceof String;
+        }
+
+        @Override
+        protected boolean isValid(Object testedPropertyValue, Object validatorPropertyValue) {
+            return testedPropertyValue instanceof String &&
+                    validatorPropertyValue instanceof String &&
+                    testedPropertyValue.equals(validatorPropertyValue);
+        }
+    }
+}

--- a/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
+++ b/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
@@ -24,9 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class CustomPropertyValidatorTest {
 
@@ -34,7 +32,7 @@ public class CustomPropertyValidatorTest {
      * Tests "happy-path" custom validation.
      */
     @Test
-    public void testCustomPropertyValidation() {
+    public void testCustomValidatorsUsed() {
         final ValidationSettings validationSettings = ValidationSettings.configure()
                 .customValidators(new CustomIntByNamePropertyValidator("intProp1", "intProp2"), new CustomStringPropertyValidator())
                 .build();
@@ -56,6 +54,32 @@ public class CustomPropertyValidatorTest {
         final PropertyValidator stringProp2Validator = validatorFactory.create(null, "go away", "go away");
         assertTrue(stringProp2Validator.isValid("go away", "go away"));
         assertEquals(stringProp1Validator, stringProp2Validator, "Expected the same validator to be used for named and unnamed string property validations");
+    }
+
+    @Test
+    public void testCustomValidatorNotUsed() {
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidators(new CustomIntByNamePropertyValidator("intProp1", "intProp2"))
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator validator = validatorFactory.create("intProp3", 42, 42);
+        assertTrue(validator.isValid(42, 42));
+        assertFalse(validator instanceof CustomPropertyValidator, "Did not expect validator to be a CustomPropertyValidator");
+    }
+
+    @Test
+    public void testValidationFailureForTypeIncompatibility() {
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidators(new CustomIntByNamePropertyValidator("intProp4"))
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator validator = validatorFactory.create("intProp4", 42, 42);
+        assertTrue(validator instanceof CustomPropertyValidator, "Expected validator to be a CustomPropertyValidator");
+        assertFalse(validator.isValid("not-an-int", "not-an-int"), "Expected validation failure as validator is testing types for which it was not created to validate");
     }
 
 

--- a/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
+++ b/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
@@ -15,7 +15,6 @@
  */
 package com.hpe.caf.worker.testing.validation;
 
-import com.google.common.base.Strings;
 import com.hpe.caf.worker.testing.TestConfiguration;
 import com.hpe.caf.worker.testing.configuration.ValidationSettings;
 import org.testng.annotations.Test;
@@ -33,69 +32,141 @@ public class CustomPropertyValidatorTest {
      */
     @Test
     public void testCustomValidatorsUsed() {
+        final String INT_PROP_1 = "intProp1";
+        final String INT_PROP_2 = "intProp2";
+        final String STRING_PROP_1 = "stringProp1";
+
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidators(new CustomIntByNamePropertyValidator("intProp1", "intProp2"), new CustomStringPropertyValidator())
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2), new CustomIntPropertyValidator(), new CustomStringPropertyValidator())
                 .build();
 
         final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
-        final PropertyValidator namedIntProp1Validator = validatorFactory.create("intProp1", 42, 42);
+        final PropertyValidator namedIntProp1Validator = validatorFactory.create(INT_PROP_1, 42, 42);
+        assertTrue(namedIntProp1Validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
         assertTrue(namedIntProp1Validator.isValid(42, 42));
-        final PropertyValidator namedIntProp2Validator = validatorFactory.create("intProp2", 999, 999);
+
+        final PropertyValidator namedIntProp2Validator = validatorFactory.create(INT_PROP_2, 999, 999);
+        assertTrue(namedIntProp2Validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
         assertTrue(namedIntProp2Validator.isValid(999, 999));
-        assertEquals(namedIntProp1Validator, namedIntProp2Validator, "Expected the same validator to be used for both unnamed int property validations");
+
+        assertEquals(namedIntProp1Validator, namedIntProp2Validator, "Expected the same validator instance to be used for both named int property validations as we've configured a CustomIntPropertyValidator that accepts the names of both properties being validated");
 
         final PropertyValidator unnamedIntPropValidator = validatorFactory.create(null, 42, 42);
+        assertTrue(unnamedIntPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that ignores the name of the property being validated");
         assertTrue(unnamedIntPropValidator.isValid(42, 42));
-        assertNotEquals(namedIntProp1Validator, unnamedIntPropValidator, "Expected different validators to be used for named and unnamed int property validations");
 
-        final PropertyValidator stringProp1Validator = validatorFactory.create("stringProp1", "hello world", "hello world");
-        assertTrue(stringProp1Validator.isValid("hello world", "hello world"));
-        final PropertyValidator stringProp2Validator = validatorFactory.create(null, "go away", "go away");
-        assertTrue(stringProp2Validator.isValid("go away", "go away"));
-        assertEquals(stringProp1Validator, stringProp2Validator, "Expected the same validator to be used for named and unnamed string property validations");
+        assertNotEquals(namedIntProp1Validator, unnamedIntPropValidator, "Expected different validator instances for named and unnamed int property validations");
+
+        final PropertyValidator namedStringPropValidator = validatorFactory.create(STRING_PROP_1, "hello world", "hello world");
+        assertTrue(namedStringPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of the property being validated");
+        assertTrue(namedStringPropValidator.isValid("hello world", "hello world"));
+
+        final PropertyValidator unnamedStringPropValidator = validatorFactory.create(null, "go away", "go away");
+        assertTrue(unnamedStringPropValidator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomStringPropertyValidator that ignores the name of the property being validated");
+        assertTrue(unnamedStringPropValidator.isValid("go away", "go away"));
+
+        assertEquals(namedStringPropValidator, unnamedStringPropValidator, "Expected the same validator instance to be used for both named and unnamed string property validations as we've configured a CustomStringPropertyValidator that ignores the names of the property being validated");
     }
 
     @Test
-    public void testCustomValidatorNotUsed() {
+    public void testCustomValidatorCreatedWithDifferingPropertyValues() {
+        final String INT_PROP_1 = "intProp1";
+
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidators(new CustomIntByNamePropertyValidator("intProp1", "intProp2"))
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1))
                 .build();
 
         final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
-        final PropertyValidator validator = validatorFactory.create("intProp3", 42, 42);
+        final PropertyValidator validator = validatorFactory.create(INT_PROP_1, 42, 53);
+        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator for named int property validation despite specifying differing values when creating the validator, as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertFalse(validator.isValid(42, 53));
+    }
+
+    @Test
+    public void testCustomValidatorCreatedWithDifferingUnnamedPropertyValues() {
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidators(new CustomIntPropertyValidator())
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator validator = validatorFactory.create(null, 42, 53);
+        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator for unnamed int property validation despite specifying differing values when creating the validator, as we've configured a CustomIntPropertyValidator that ignores the name of the property being validated");
+        assertFalse(validator.isValid(42, 53));
+    }
+
+    @Test
+    public void testCustomValidatorNotUsedAsPropNameNotRecognized() {
+        final String INT_PROP_1 = "intProp1";
+        final String INT_PROP_2 = "intProp2";
+        final String INT_PROP_3 = "intProp3";
+
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2))
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator validator = validatorFactory.create(INT_PROP_3, 42, 42);
+        assertFalse(validator instanceof CustomPropertyValidator, "Did not expect a CustomPropertyValidator as the configured CustomPropertyValidator does not accept the named property being validated");
         assertTrue(validator.isValid(42, 42));
-        assertFalse(validator instanceof CustomPropertyValidator, "Did not expect validator to be a CustomPropertyValidator");
     }
 
     @Test
-    public void testValidationFailureForTypeIncompatibility() {
+    public void testValidationFailureForValidationTypeIncompatibleWithValidator() {
+        final String INT_PROP_1 = "intProp1";
+
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidators(new CustomIntByNamePropertyValidator("intProp4"))
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1))
                 .build();
 
         final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
 
-        final PropertyValidator validator = validatorFactory.create("intProp4", 42, 42);
-        assertTrue(validator instanceof CustomPropertyValidator, "Expected validator to be a CustomPropertyValidator");
-        assertFalse(validator.isValid("not-an-int", "not-an-int"), "Expected validation failure as validator is testing types for which it was not created to validate");
+        final PropertyValidator validator = validatorFactory.create(INT_PROP_1, 42, 42);
+        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertFalse(validator.isValid("not-an-int", "not-an-int"), "Expected validation failure as the validator is testing types that it was not created to validate");
+    }
+
+    @Test
+    public void testChooseFirstOfMultipleApplicableValidators() {
+        final String INT_PROP_1 = "intProp1";
+        final String INT_PROP_2 = "intProp2";
+        final String INT_PROP_3 = "intProp3";
+
+        final ValidationSettings validationSettings = ValidationSettings.configure()
+                .customValidators(new CustomIntPropertyValidator(INT_PROP_1, INT_PROP_2), new CustomIntPropertyValidator(INT_PROP_2, INT_PROP_3))
+                .build();
+
+        final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));
+
+        final PropertyValidator validator = validatorFactory.create(INT_PROP_2, 42, 42);
+        assertTrue(validator instanceof CustomPropertyValidator, "Expected a CustomPropertyValidator as we've configured a CustomIntPropertyValidator that accepts the name of the property being validated");
+        assertTrue(validator instanceof CustomIntPropertyValidator, "Expected the validator to be specifically a CustomIntPropertyValidator");
+
+        CustomIntPropertyValidator customIntValidator = (CustomIntPropertyValidator)validator;
+        assertEquals(customIntValidator.getRecognizedPropertyNames().size(), 2, "Expected to use the configured CustomIntPropertyValidator that recognizes 2 property names");
+        assertTrue(customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_1) && customIntValidator.getRecognizedPropertyNames().contains(INT_PROP_2), "Expected to use the configured CustomIntPropertyValidator that recognizes the property names \"" + INT_PROP_1 + "\" and \"" + INT_PROP_2 + "\"");
+        assertTrue(validator.isValid(42, 42));
     }
 
 
-    private static class CustomIntByNamePropertyValidator extends CustomPropertyValidator {
+    private static class CustomIntPropertyValidator extends CustomPropertyValidator {
         private Collection<String> recognizedPropertyNames = new ArrayList<>();
 
-        public CustomIntByNamePropertyValidator(final String... recognizedPropertyNames) {
+        public CustomIntPropertyValidator(final String... recognizedPropertyNames) {
             this.recognizedPropertyNames = new ArrayList<>(Arrays.asList(recognizedPropertyNames));
+        }
+
+        public Collection<String> getRecognizedPropertyNames() {
+            return recognizedPropertyNames;
         }
 
         @Override
         public boolean canValidate(String propertyName, Object sourcePropertyValue, Object validatorPropertyValue) {
-            return !Strings.isNullOrEmpty(propertyName) &&
-                    recognizedPropertyNames.contains(propertyName) &&
-                    sourcePropertyValue instanceof Integer &&
-                    validatorPropertyValue instanceof Integer;
+            final boolean nameCheckPassed = recognizedPropertyNames.isEmpty() || recognizedPropertyNames.contains(propertyName);
+            return nameCheckPassed && sourcePropertyValue instanceof Integer && validatorPropertyValue instanceof Integer;
         }
 
         @Override

--- a/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
+++ b/worker-testing-integration/src/test/java/com/hpe/caf/worker/testing/validation/CustomPropertyValidatorTest.java
@@ -36,7 +36,7 @@ public class CustomPropertyValidatorTest {
     @Test
     public void testCustomPropertyValidation() {
         final ValidationSettings validationSettings = ValidationSettings.configure()
-                .customValidationProperties(new CustomIntByNamePropertyValidator("intProp1", "intProp2"), new CustomStringPropertyValidator())
+                .customValidators(new CustomIntByNamePropertyValidator("intProp1", "intProp2"), new CustomStringPropertyValidator())
                 .build();
 
         final ValidatorFactory validatorFactory = new ValidatorFactory(validationSettings, null, null, TestConfiguration.createDefault(null, null, null, null));


### PR DESCRIPTION
Work-in-progress: In particular, I'm uncomfortable with ValidatorFactory not returning a fresh CustomPropertyValidator instance on each call to create().