### PR TITLE
CAF-2375: Alphabetically order yaml testcases

### DIFF
--- a/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/TestConfiguration.java
+++ b/worker-testing-integration/src/main/java/com/hpe/caf/worker/testing/TestConfiguration.java
@@ -16,6 +16,7 @@
 package com.hpe.caf.worker.testing;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
@@ -57,6 +58,9 @@ public class TestConfiguration<TWorkerTask, TWorkerResult, TInput, TExpectation>
         }
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+        mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+
         mapper.registerModule(new GuavaModule());
 
         boolean processSubFolders = SettingsProvider.defaultProvider.getBooleanSetting(SettingNames.processSubFolders, true);


### PR DESCRIPTION
Enabling features on the ObjectMapper to sort properties alphabetically and order map entries.