### PR TITLE
Remove provider registration for In-Memory data store

### DIFF
--- a/worker-store-mem/src/main/resources/META-INF/services/com.hpe.caf.api.worker.DataStoreProvider
+++ b/worker-store-mem/src/main/resources/META-INF/services/com.hpe.caf.api.worker.DataStoreProvider
@@ -1,1 +1,0 @@
-com.hpe.caf.worker.datastore.mem.InMemoryDataStoreProvider


### PR DESCRIPTION
Workers were picking up this provider in a container due to Module Loader limitations.