### PR TITLE
CAF-2942: Add some code to set the log level

### DIFF
--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
@@ -15,7 +15,6 @@
  */
 package com.hpe.caf.worker.core;
 
-import ch.qos.logback.classic.Level;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.hpe.caf.api.BootstrapConfiguration;
@@ -47,8 +46,6 @@ import com.hpe.caf.util.jerseycompat.Jersey2ServiceIteratorProvider;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.logging.LoggingFactory;
-import io.dropwizard.servlets.tasks.LogConfigurationTask;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.internal.ServiceFinder;
@@ -103,7 +100,6 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
         
         ResponseCache.setDefault(new JobStatusResponseCache());
         BootstrapConfiguration bootstrap = new SystemBootstrapConfiguration();
-        setWorkerLogLevel(workerConfiguration, bootstrap);
         Cipher cipher = ModuleLoader.getService(CipherProvider.class, NullCipherProvider.class).getCipher(bootstrap);
         ServicePath path = bootstrap.getServicePath();
         Codec codec = ModuleLoader.getService(Codec.class);
@@ -157,39 +153,6 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
         );
     }
 
-    private static void setWorkerLogLevel(
-        final WorkerConfiguration workerConfig,
-        final BootstrapConfiguration bootstrapConfig
-    )
-    {
-        final String LOG_LEVEL_CONFIG_KEY = "CAF_LOG_LEVEL";
-
-        if (!bootstrapConfig.isConfigurationPresent(LOG_LEVEL_CONFIG_KEY)) {
-            return;
-        }
-
-        if (workerConfig == null) {
-            return;
-        }
-
-        final LoggingFactory loggingFactory = workerConfig.getLoggingFactory();
-        if (loggingFactory == null) {
-            return;
-        }
-
-        final String logLevelStr;
-        try {
-            logLevelStr = bootstrapConfig.getConfiguration(LOG_LEVEL_CONFIG_KEY);
-        } catch (final ConfigurationException ex) {
-            // Throw a RuntimeException since this shouldn't happen
-            // (since isConfigurationPresent() has already been called)
-            throw new RuntimeException(ex);
-        }
-
-        final Level logLevel = Level.toLevel(logLevelStr);
-
-        loggingFactory.setLevel(logLevel);
-    }
 
     private void initCoreMetrics(final MetricRegistry metrics, final WorkerCore core)
     {

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
@@ -143,16 +143,14 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
         environment.healthChecks().register("worker", new WorkerHealthCheck(workerFactory));
         core.start();
     }
-    
+
     @Override
-    public void initialize(Bootstrap<WorkerConfiguration> bootstrap){
+    public void initialize(Bootstrap<WorkerConfiguration> bootstrap)
+    {
         bootstrap.setConfigurationSourceProvider(
-                new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
-                                                   new EnvironmentVariableSubstitutor()
-                )
+            new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false, true))
         );
     }
-
 
     private void initCoreMetrics(final MetricRegistry metrics, final WorkerCore core)
     {


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2942

@Anthony-McGreevy How about if we just added some code like this to Worker Framework?  I.e. leave the existing file alone, and use `CAF_LOG_LEVEL` to override it.  If that works it should centralise the logic rather than having to modify all the containers.

BTW: I haven't even compiled the code below nevermind tested it.