### PR TITLE
CAF-2852: Adjusted StreamingWorkerThreadPool to handle exceptions…

### DIFF
--- a/worker-core/src/main/java/com/hpe/caf/worker/core/StreamingWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/StreamingWorkerThreadPool.java
@@ -126,7 +126,7 @@ final class StreamingWorkerThreadPool implements WorkerThreadPool {
                     try {
                         ((Future<?>) r).get();
                     } catch (CancellationException ce) {
-                        t = ce;
+                        LOG.error("Thread returned a CancellationException with message " + ce.getMessage(), ce);
                     } catch (ExecutionException ee) {
                         t = ee.getCause();
                     } catch (InterruptedException ie) {

--- a/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerCoreTest.java
+++ b/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerCoreTest.java
@@ -190,7 +190,7 @@ public class WorkerCoreTest
     {
         BlockingQueue<byte[]> q = new LinkedBlockingQueue<>();
         Codec codec = new JsonCodec();
-        WorkerThreadPool wtp = WorkerThreadPool.create(2);
+        WorkerThreadPool wtp = WorkerThreadPool.create(2, () -> System.out.println("Hit runnable due to interruption"));
         ConfigurationSource config = Mockito.mock(ConfigurationSource.class);
         ServicePath path = new ServicePath(SERVICE_PATH);
         TestWorkerTask task = new TestWorkerTask();

--- a/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerCoreTest.java
+++ b/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerCoreTest.java
@@ -190,7 +190,7 @@ public class WorkerCoreTest
     {
         BlockingQueue<byte[]> q = new LinkedBlockingQueue<>();
         Codec codec = new JsonCodec();
-        WorkerThreadPool wtp = WorkerThreadPool.create(2, () -> System.out.println("Hit runnable due to interruption"));
+        WorkerThreadPool wtp = WorkerThreadPool.create(2);
         ConfigurationSource config = Mockito.mock(ConfigurationSource.class);
         ServicePath path = new ServicePath(SERVICE_PATH);
         TestWorkerTask task = new TestWorkerTask();

--- a/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerExecutorTest.java
+++ b/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerExecutorTest.java
@@ -34,14 +34,16 @@ public class WorkerExecutorTest
 {
     @Test
     public void testExecuteTask()
-        throws InvalidNameException, TaskRejectedException, InvalidTaskException
+        throws InvalidNameException, TaskRejectedException, InvalidTaskException, InterruptedException
     {
         ServicePath path = new ServicePath("/unitTest/test");
         WorkerCallback callback = Mockito.mock(WorkerCallback.class);
         Worker worker = Mockito.mock(Worker.class);
+        WorkerResponse workerResponse = new WorkerResponse("testQueue", TaskStatus.NEW_TASK, new byte[0], "testType", 1, new byte[0]);
+        Mockito.when(worker.doWork()).thenReturn(workerResponse);
         WorkerFactory factory = Mockito.mock(WorkerFactory.class);
         Mockito.when(factory.getWorker(Mockito.any())).thenReturn(worker);
-        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testExecuteTask"));
+        WorkerThreadPool pool = WorkerThreadPool.create(5);
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
 
@@ -118,7 +120,7 @@ public class WorkerExecutorTest
         WorkerFactory factory = Mockito.mock(WorkerFactory.class);
         Mockito.when(factory.getWorker(Mockito.any())).thenThrow(
             TaskRejectedException.class);
-        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testRejectTask"));
+        WorkerThreadPool pool = WorkerThreadPool.create(5);
 
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
         TaskMessage tm = new TaskMessage("test", "test", 1, "test".getBytes(StandardCharsets.UTF_8), TaskStatus.NEW_TASK, new HashMap<>(), "test");
@@ -157,7 +159,7 @@ public class WorkerExecutorTest
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
 
-        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testInvalidTask"));
+        WorkerThreadPool pool = WorkerThreadPool.create(5);
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
 
         TaskMessage tm = new TaskMessage(taskId, classifier, ver, data, TaskStatus.NEW_TASK, new HashMap<>(), "queue");
@@ -197,7 +199,7 @@ public class WorkerExecutorTest
             InvalidTaskException.class);
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
-        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testEvenMoreInvalidTask"));
+        WorkerThreadPool pool = WorkerThreadPool.create(5);
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
 
         TaskMessage tm = new TaskMessage(taskId, classifier, ver, data, TaskStatus.NEW_TASK, new HashMap<>(), "queue");

--- a/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerExecutorTest.java
+++ b/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerExecutorTest.java
@@ -41,7 +41,7 @@ public class WorkerExecutorTest
         Worker worker = Mockito.mock(Worker.class);
         WorkerFactory factory = Mockito.mock(WorkerFactory.class);
         Mockito.when(factory.getWorker(Mockito.any())).thenReturn(worker);
-        WorkerThreadPool pool = WorkerThreadPool.create(5);
+        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testExecuteTask"));
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
 
@@ -118,7 +118,7 @@ public class WorkerExecutorTest
         WorkerFactory factory = Mockito.mock(WorkerFactory.class);
         Mockito.when(factory.getWorker(Mockito.any())).thenThrow(
             TaskRejectedException.class);
-        WorkerThreadPool pool = WorkerThreadPool.create(5);
+        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testRejectTask"));
 
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
         TaskMessage tm = new TaskMessage("test", "test", 1, "test".getBytes(StandardCharsets.UTF_8), TaskStatus.NEW_TASK, new HashMap<>(), "test");
@@ -157,7 +157,7 @@ public class WorkerExecutorTest
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
 
-        WorkerThreadPool pool = WorkerThreadPool.create(5);
+        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testInvalidTask"));
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
 
         TaskMessage tm = new TaskMessage(taskId, classifier, ver, data, TaskStatus.NEW_TASK, new HashMap<>(), "queue");
@@ -197,7 +197,7 @@ public class WorkerExecutorTest
             InvalidTaskException.class);
         MessagePriorityManager priorityManager = Mockito.mock(MessagePriorityManager.class);
         Mockito.when(priorityManager.getResponsePriority(Mockito.any())).thenReturn(2);
-        WorkerThreadPool pool = WorkerThreadPool.create(5);
+        WorkerThreadPool pool = WorkerThreadPool.create(5, () -> System.out.println("testEvenMoreInvalidTask"));
         WorkerExecutor executor = new WorkerExecutor(path, callback, factory, pool, priorityManager);
 
         TaskMessage tm = new TaskMessage(taskId, classifier, ver, data, TaskStatus.NEW_TASK, new HashMap<>(), "queue");

--- a/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerThreadPoolTest.java
+++ b/worker-core/src/test/java/com/hpe/caf/worker/core/WorkerThreadPoolTest.java
@@ -18,6 +18,7 @@ package com.hpe.caf.worker.core;
 import com.hpe.caf.api.worker.InvalidTaskException;
 import com.hpe.caf.api.worker.TaskRejectedException;
 import com.hpe.caf.api.worker.Worker;
+import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -41,5 +42,7 @@ public class WorkerThreadPoolTest
 
         wtp.submitWorkerTask(mockWorkerTask);
         latch.await(1, TimeUnit.SECONDS);
+        Assert.assertEquals("Latch count should be 0; indicating that the handler was invoked due to the Error thrown",
+                0, latch.getCount());
     }
 }


### PR DESCRIPTION
…returned from workers correctly so that the throwable handler is ran. Adjusted tests to match changes.