### PR TITLE
CAF-2670: Changes to enable support for resetting the 'trackTo' field to null when a job has no sub tasks.

### DIFF
--- a/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
+++ b/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
@@ -28,6 +28,7 @@ public class WorkerResponse
     private final String messageType;
     private final int apiVersion;
     private final byte[] context;
+    private final boolean resetTrackTo;
 
     /**
      * Create a new WorkerResponse.
@@ -41,6 +42,22 @@ public class WorkerResponse
      */
     public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context)
     {
+        this(queue, status, data, msgType, version, context, false);
+    }
+
+    /**
+     * Create a new WorkerResponse.
+     *
+     * @param queue the reference to the queue that the response data should be put upon. This can be null if no queue is provided
+     * @param status the status of the message the Worker is returning
+     * @param data the serialised task-specific data returned from the Worker internals
+     * @param msgType the task-specific message classifier
+     * @param version the task-specific message API version
+     * @param context the new context to add to the task message, can be null
+     * @param resetTrackTo indicates if the tracking 'trackTo' field should be reset
+     */
+    public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context, boolean resetTrackTo)
+    {
         this.queueReference = queue; // queueReference can be 'null' for a dead end worker and
         // 'null' for a worker who does not send success messages to
         // it's output queue
@@ -49,6 +66,7 @@ public class WorkerResponse
         this.messageType = Objects.requireNonNull(msgType);
         this.apiVersion = version;
         this.context = context;
+        this.resetTrackTo = resetTrackTo;
     }
 
     public TaskStatus getTaskStatus()
@@ -79,5 +97,10 @@ public class WorkerResponse
     public byte[] getContext()
     {
         return context;
+    }
+
+    public boolean getResetTrackTo()
+    {
+        return resetTrackTo;
     }
 }

--- a/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
+++ b/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
@@ -56,7 +56,7 @@ public class WorkerResponse
      * @param context the new context to add to the task message, can be null
      * @param resetTrackTo indicates if the tracking 'trackTo' field should be reset
      */
-    public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context, boolean resetTrackTo)
+    public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context, final boolean resetTrackTo)
     {
         this.queueReference = queue; // queueReference can be 'null' for a dead end worker and
         // 'null' for a worker who does not send success messages to

--- a/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
+++ b/worker-api/src/main/java/com/hpe/caf/api/worker/WorkerResponse.java
@@ -28,7 +28,7 @@ public class WorkerResponse
     private final String messageType;
     private final int apiVersion;
     private final byte[] context;
-    private final boolean resetTrackTo;
+    private final String trackTo;
 
     /**
      * Create a new WorkerResponse.
@@ -42,7 +42,7 @@ public class WorkerResponse
      */
     public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context)
     {
-        this(queue, status, data, msgType, version, context, false);
+        this(queue, status, data, msgType, version, context, "");
     }
 
     /**
@@ -54,9 +54,9 @@ public class WorkerResponse
      * @param msgType the task-specific message classifier
      * @param version the task-specific message API version
      * @param context the new context to add to the task message, can be null
-     * @param resetTrackTo indicates if the tracking 'trackTo' field should be reset
+     * @param trackTo the tracking 'trackTo' pipe to set
      */
-    public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context, final boolean resetTrackTo)
+    public WorkerResponse(final String queue, final TaskStatus status, final byte[] data, final String msgType, final int version, final byte[] context, final String trackTo)
     {
         this.queueReference = queue; // queueReference can be 'null' for a dead end worker and
         // 'null' for a worker who does not send success messages to
@@ -66,7 +66,7 @@ public class WorkerResponse
         this.messageType = Objects.requireNonNull(msgType);
         this.apiVersion = version;
         this.context = context;
-        this.resetTrackTo = resetTrackTo;
+        this.trackTo = trackTo;
     }
 
     public TaskStatus getTaskStatus()
@@ -99,8 +99,8 @@ public class WorkerResponse
         return context;
     }
 
-    public boolean getResetTrackTo()
+    public String getTrackTo()
     {
-        return resetTrackTo;
+        return trackTo;
     }
 }

--- a/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
+++ b/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
@@ -132,18 +132,18 @@ public abstract class AbstractWorker<T, V> implements Worker
      */
     protected final WorkerResponse createSuccessNoOutputToQueue()
     {
-        return createSuccessNoOutputToQueue(false);
+        return createSuccessNoOutputToQueue("");
     }
 
     /**
      * Utility method for creating a WorkerReponse that represents a success, but does not send a message to the worker's output message.
      *
-     * @param resetTrackTo indicates if the tracking 'trackTo' field should be reset
+     * @param trackTo the tracking 'trackTo' pipe to set
      * @return a WorkerResponse that represents a success
      */
-    protected final WorkerResponse createSuccessNoOutputToQueue(final boolean resetTrackTo)
+    protected final WorkerResponse createSuccessNoOutputToQueue(final String trackTo)
     {
-        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, resetTrackTo);
+        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, trackTo);
     }
 
     /**

--- a/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
+++ b/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
@@ -130,9 +130,9 @@ public abstract class AbstractWorker<T, V> implements Worker
      *
      * @return a WorkerResponse that represents a success
      */
-    protected final WorkerResponse createSuccessNoOutputToQueue()
+    protected final WorkerResponse createSuccessNoOutputToQueue(boolean resetTrackTo)
     {
-        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null);
+        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, resetTrackTo);
     }
 
     /**

--- a/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
+++ b/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
@@ -130,7 +130,18 @@ public abstract class AbstractWorker<T, V> implements Worker
      *
      * @return a WorkerResponse that represents a success
      */
-    protected final WorkerResponse createSuccessNoOutputToQueue(boolean resetTrackTo)
+    protected final WorkerResponse createSuccessNoOutputToQueue()
+    {
+        return createSuccessNoOutputToQueue(false);
+    }
+
+    /**
+     * Utility method for creating a WorkerReponse that represents a success, but does not send a message to the worker's output message.
+     *
+     * @param resetTrackTo indicates if the tracking 'trackTo' field should be reset
+     * @return a WorkerResponse that represents a success
+     */
+    protected final WorkerResponse createSuccessNoOutputToQueue(final boolean resetTrackTo)
     {
         return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, resetTrackTo);
     }

--- a/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
+++ b/worker-caf/src/main/java/com/hpe/caf/worker/AbstractWorker.java
@@ -126,24 +126,24 @@ public abstract class AbstractWorker<T, V> implements Worker
     }
 
     /**
-     * Utility method for creating a WorkerReponse that represents a success, but does not send a message to the worker's output message.
+     * Utility method for creating a WorkerResponse that represents a success, but does not send a message to the worker's output message.
      *
      * @return a WorkerResponse that represents a success
      */
     protected final WorkerResponse createSuccessNoOutputToQueue()
     {
-        return createSuccessNoOutputToQueue("");
+        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null);
     }
 
     /**
-     * Utility method for creating a WorkerReponse that represents a success, but does not send a message to the worker's output message.
+     * Utility method for creating a WorkerResponse that represents a success, but does not send a message to the worker's output message.
+     * This method would be used to set target queue and final tracking queue to null.
      *
-     * @param trackTo the tracking 'trackTo' pipe to set
      * @return a WorkerResponse that represents a success
      */
-    protected final WorkerResponse createSuccessNoOutputToQueue(final String trackTo)
+    protected final WorkerResponse createTaskCompleteResponse()
     {
-        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, trackTo);
+        return new WorkerResponse(null, TaskStatus.RESULT_SUCCESS, new byte[]{}, getWorkerIdentifier(), getWorkerApiVersion(), null, null);
     }
 
     /**

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerCore.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerCore.java
@@ -502,10 +502,10 @@ final class WorkerCore
             Objects.requireNonNull(tm);
             // queueToSend can be null for a dead end worker
 
-            TrackingInfo tracking = tm.getTracking();
+            final TrackingInfo tracking = tm.getTracking();
             if (tracking != null) {
-                String trackTo = tracking.getTrackTo();
-                if (trackTo != null && trackTo.equalsIgnoreCase(queueToSend)) {
+                final String trackTo = tracking.getTrackTo();
+                if ((trackTo == null && queueToSend == null) || (trackTo != null && trackTo.equalsIgnoreCase(queueToSend))) {
                     LOG.debug("Task {} (message id: {}): removing tracking info from this message as tracking ends on publishing to the queue {}.", tm.getTaskId(), queueMsgId, queueToSend);
                     tm.setTracking(null);
                 }

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -147,12 +147,10 @@ class WorkerTaskImpl implements WorkerTask
         final TrackingInfo trackingInfo;
         if (response.getResetTrackTo()) {
             //  Reset trackTo field to null;
-            final TrackingInfo taskMessageTracking = taskMessage.getTracking();
-            trackingInfo = new TrackingInfo(taskMessageTracking.getJobTaskId(),
-                    taskMessageTracking.getStatusCheckTime(),
-                    taskMessageTracking.getStatusCheckUrl(),
-                    taskMessageTracking.getTrackingPipe(),
-                    null);
+            trackingInfo = taskMessage.getTracking();
+            if (trackingInfo != null) {
+                trackingInfo.setTrackTo(null);
+            }
         } else {
             //  No tracking changes required.
             trackingInfo = taskMessage.getTracking();

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -143,11 +143,26 @@ class WorkerTaskImpl implements WorkerTask
 
         final String responseMessageType = response.getMessageType();
 
+        //  Check if the 'trackTo' field needs to be reset.
+        final TrackingInfo trackingInfo;
+        if (response.getResetTrackTo()) {
+            //  Reset trackTo field to null;
+            final TrackingInfo taskMessageTracking = taskMessage.getTracking();
+            trackingInfo = new TrackingInfo(taskMessageTracking.getJobTaskId(),
+                    taskMessageTracking.getStatusCheckTime(),
+                    taskMessageTracking.getStatusCheckUrl(),
+                    taskMessageTracking.getTrackingPipe(),
+                    null);
+        } else {
+            //  No tracking changes required.
+            trackingInfo = taskMessage.getTracking();
+        }
+
         final TaskMessage responseMessage = new TaskMessage(
             taskMessage.getTaskId(), responseMessageType,
             response.getApiVersion(), response.getData(),
             response.getTaskStatus(), responseContext,
-            response.getQueueReference(), taskMessage.getTracking(),
+            response.getQueueReference(), trackingInfo,
             new TaskSourceInfo(getWorkerName(responseMessageType), getWorkerVersion()));
         responseMessage.setPriority(priorityManager.getResponsePriority(taskMessage));
 

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -143,17 +143,19 @@ class WorkerTaskImpl implements WorkerTask
 
         final String responseMessageType = response.getMessageType();
 
-        //  Check if the 'trackTo' field needs to be reset.
+        //  Check if a tracking change is required.
         final TrackingInfo trackingInfo;
-        if (response.getResetTrackTo()) {
-            //  Reset trackTo field to null;
-            trackingInfo = taskMessage.getTracking();
-            if (trackingInfo != null) {
-                trackingInfo.setTrackTo(null);
+        if (null != response.getTrackTo()) {
+            if (response.getTrackTo().equals("") || (response.getTrackTo().equals(taskMessage.getTracking().getTrackTo()))) {
+                //  No tracking changes required.
+                trackingInfo = taskMessage.getTracking();
+            } else {
+                //  The trackTo value does not match the existing task message value, so update required.
+                trackingInfo = getTrackingInfoWithChanges(response.getTrackTo());
             }
         } else {
-            //  No tracking changes required.
-            trackingInfo = taskMessage.getTracking();
+            //  The trackTo value has been set to null so we require an update.
+            trackingInfo = getTrackingInfoWithChanges(null);
         }
 
         final TaskMessage responseMessage = new TaskMessage(
@@ -165,6 +167,18 @@ class WorkerTaskImpl implements WorkerTask
         responseMessage.setPriority(priorityManager.getResponsePriority(taskMessage));
 
         return responseMessage;
+    }
+
+    private TrackingInfo getTrackingInfoWithChanges(final String trackTo) {
+        TrackingInfo trackingInfo = null;
+
+        final TrackingInfo taskMessageTracking = taskMessage.getTracking();
+        if (taskMessageTracking != null) {
+            trackingInfo = new TrackingInfo(taskMessageTracking);
+            trackingInfo.setTrackTo(trackTo);
+        }
+
+        return trackingInfo;
     }
 
     @Override

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerTaskImpl.java
@@ -143,19 +143,14 @@ class WorkerTaskImpl implements WorkerTask
 
         final String responseMessageType = response.getMessageType();
 
-        //  Check if a tracking change is required.
+        //  Check if a tracking change is required. If empty string then no further changes required.
         final TrackingInfo trackingInfo;
-        if (null != response.getTrackTo()) {
-            if (response.getTrackTo().equals("") || (response.getTrackTo().equals(taskMessage.getTracking().getTrackTo()))) {
-                //  No tracking changes required.
-                trackingInfo = taskMessage.getTracking();
-            } else {
-                //  The trackTo value does not match the existing task message value, so update required.
-                trackingInfo = getTrackingInfoWithChanges(response.getTrackTo());
-            }
+        if ("".equals(response.getTrackTo())) {
+            //  No tracking changes required.
+            trackingInfo = taskMessage.getTracking();
         } else {
-            //  The trackTo value has been set to null so we require an update.
-            trackingInfo = getTrackingInfoWithChanges(null);
+            //  Set trackTo field to the specified value.
+            trackingInfo = getTrackingInfoWithChanges(response.getTrackTo());
         }
 
         final TaskMessage responseMessage = new TaskMessage(


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2670

I have introduced changes to the WF to support the completion of job with no subtasks.
This change allows the tracking 'trackTo' field to be set to null. The batch worker will utilise these changes.

Associated PRs for CAF-2670:
Worker-Batch: https://github.com/JobService/worker-batch/pull/6
Worker-GlobFilter: https://github.com/JobService/worker-globfilter/pull/4
Job-Service: https://github.com/JobService/job-service/pull/32