### PR TITLE
Configurable test worker healthcheck.

### DIFF
--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
@@ -337,6 +337,7 @@
                                     <CAF_RABBITMQ_MAX_ATTEMPTS>20</CAF_RABBITMQ_MAX_ATTEMPTS>
                                     <CAF_RABBITMQ_PREFETCH_BUFFER>0</CAF_RABBITMQ_PREFETCH_BUFFER>
                                     <CAF_WORKER_RETRY_LIMIT>2</CAF_WORKER_RETRY_LIMIT>
+                                    <CAF_EXAMPLE_WORKER_HEALTHY>true</CAF_EXAMPLE_WORKER_HEALTHY>
                                 </env>
                                 <volumes>
                                     <from>

--- a/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__/src/main/java/__workerName__HealthCheck.java
+++ b/worker-archetype/src/main/resources/archetype-resources/__rootArtifactId__/src/main/java/__workerName__HealthCheck.java
@@ -20,6 +20,8 @@ package ${package};
 
 import com.hpe.caf.api.HealthReporter;
 import com.hpe.caf.api.HealthResult;
+import com.hpe.caf.api.HealthStatus;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,8 @@ public class ${workerName}HealthCheck implements HealthReporter {
     //for logging.
     private static final Logger LOG = LoggerFactory.getLogger(${workerName}.class);
 
+    private static final String CAF_EXAMPLE_WORKER_HEALTHY = "CAF_EXAMPLE_WORKER_HEALTHY";
+
     public ${workerName}HealthCheck() {
     }
 
@@ -41,10 +45,16 @@ public class ${workerName}HealthCheck implements HealthReporter {
      */
     @Override
     public HealthResult healthCheck() {
-        // Check that all worker components are available. If the worker depends on an external service, check that the service is accessible here.
-        // In this scenario, the ${workerName} does not depend on any external components. It will always return HealthResult.RESULT_HEALTHY.
-        // If a service was not available, catch any exceptions, log a warning and return a UNHEALTHY health result.
+        // If the environment variable CAF_EXAMPLE_WORKER_HEALTHY is set to false the healthCheck()
+        // will return unhealthy otherwise it will always return healthy. This adds to the Example
+        // Worker's testing and demonstration ability.
 
-        return HealthResult.RESULT_HEALTHY;
+        HealthResult result = new HealthResult(HealthStatus.HEALTHY);
+        String cafExampleWorkerHealth = System.getProperty(CAF_EXAMPLE_WORKER_HEALTHY, System.getenv(CAF_EXAMPLE_WORKER_HEALTHY));
+        if (null != cafExampleWorkerHealth && cafExampleWorkerHealth.equalsIgnoreCase("false")) {
+            LOG.debug("The Example Worker's Health Check is set to Unhealthy");
+            result = new HealthResult(HealthStatus.UNHEALTHY);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
The test worker's healthcheck can be configured via **CAF_EXAMPLE_WORKER_HEALTHY** env variable to test https://portal.digitalsafe.net/browse/SCMOD-8463.