### PR TITLE
SCMOD-9102: Update worker-store-fs healthcheck

### DIFF
--- a/worker-default-configs/README.md
+++ b/worker-default-configs/README.md
@@ -9,6 +9,7 @@ The default FileSystemDataStore configuration file checks for values as below;
 | Property | Checked Environment Variables | Default               |
 |----------|-------------------------------|-----------------------|
 | dataDir  |  `CAF_WORKER_DATASTORE_PATH` | /mnt/caf-datastore-root  |
+| dataDirHealthcheckTimeoutSeconds  |  `CAF_WORKER_DATASTORE_HEALTHCHECK_TIMEOUT_SECONDS` | 10  |
 
 
 ## RabbitConfiguration

--- a/worker-default-configs/config/cfg~caf~worker~FileSystemDataStoreConfiguration.js
+++ b/worker-default-configs/config/cfg~caf~worker~FileSystemDataStoreConfiguration.js
@@ -15,8 +15,7 @@
  */
 ({
     dataDir: getenv("CAF_WORKER_DATASTORE_PATH") || "/mnt/caf-datastore-root",
-    dataDirHealthcheckTimeoutSeconds: getenv("CAF_WORKER_DATASTORE_HEALTHCHECK_TIMEOUT_SECONDS")
-            || 10,
+    dataDirHealthcheckTimeoutSeconds: getenv("CAF_WORKER_DATASTORE_HEALTHCHECK_TIMEOUT_SECONDS") || undefined,
     outputBufferSize: getenv("CAF_WORKER_DATASTORE_OUTPUT_BUFFER_SIZE")
             || getenv("CAF_WORKER_DATASTORE_BUFFER_SIZE") || undefined
 });

--- a/worker-default-configs/config/cfg~caf~worker~FileSystemDataStoreConfiguration.js
+++ b/worker-default-configs/config/cfg~caf~worker~FileSystemDataStoreConfiguration.js
@@ -15,6 +15,8 @@
  */
 ({
     dataDir: getenv("CAF_WORKER_DATASTORE_PATH") || "/mnt/caf-datastore-root",
+    dataDirHealthcheckTimeoutSeconds: getenv("CAF_WORKER_DATASTORE_HEALTHCHECK_TIMEOUT_SECONDS")
+            || 10,
     outputBufferSize: getenv("CAF_WORKER_DATASTORE_OUTPUT_BUFFER_SIZE")
             || getenv("CAF_WORKER_DATASTORE_BUFFER_SIZE") || undefined
 });

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -65,8 +65,6 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
         throws DataStoreException
     {
         dataStorePath = FileSystems.getDefault().getPath(config.getDataDir());
-        healthcheck = new FileSystemDataStoreHealthcheck(dataStorePath);
-        healthcheckTimeout = Duration.ofSeconds(config.getDataDirHealthcheckTimeoutSeconds());
         if (!Files.exists(dataStorePath)) {
             try {
                 Files.createDirectory(dataStorePath);
@@ -74,7 +72,8 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
                 throw new DataStoreException("Cannot create data store directory", e);
             }
         }
-
+        healthcheck = new FileSystemDataStoreHealthcheck(dataStorePath);
+        healthcheckTimeout = Duration.ofSeconds(config.getDataDirHealthcheckTimeoutSeconds());
         outputBufferSize = getOutputBufferSize(config);
 
         LOG.debug("Initialised");

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -16,6 +16,7 @@
 package com.hpe.caf.worker.datastore.fs;
 
 import com.hpe.caf.api.HealthResult;
+import com.hpe.caf.api.HealthStatus;
 import com.hpe.caf.api.worker.*;
 import org.apache.commons.io.output.ProxyOutputStream;
 import org.slf4j.Logger;
@@ -26,8 +27,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.*;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -45,6 +54,9 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
     private final AtomicInteger numDx = new AtomicInteger(0);
     private final DataStoreMetricsReporter metrics = new FileSystemDataStoreMetricsReporter();
     private static final Logger LOG = LoggerFactory.getLogger(FileSystemDataStore.class);
+    private final Callable<HealthResult> healthcheck;
+    private final Duration healthcheckTimeout;
+    private final ExecutorService healthcheckExecutor = Executors.newSingleThreadExecutor();
 
     /**
      * Determine the directory for the data store, and create it if necessary.
@@ -53,6 +65,8 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
         throws DataStoreException
     {
         dataStorePath = FileSystems.getDefault().getPath(config.getDataDir());
+        healthcheck = new FileSystemDataStoreHealthcheck(dataStorePath);
+        healthcheckTimeout = Duration.ofSeconds(config.getDataDirHealthcheckTimeoutSeconds());
         if (!Files.exists(dataStorePath)) {
             try {
                 Files.createDirectory(dataStorePath);
@@ -69,7 +83,7 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
     @Override
     public void shutdown()
     {
-        // nothing to do
+        healthcheckExecutor.shutdown();
     }
 
     /**
@@ -223,7 +237,25 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
     @Override
     public HealthResult healthCheck()
     {
-        return HealthResult.RESULT_HEALTHY;
+        final Future<HealthResult> healthcheckFuture = healthcheckExecutor.submit(healthcheck);
+        try {
+            return healthcheckFuture.get(healthcheckTimeout.getSeconds(), TimeUnit.SECONDS);
+        } catch (final TimeoutException e) {
+            healthcheckFuture.cancel(true);
+            return new HealthResult(
+                HealthStatus.UNHEALTHY,
+                String.format("Timeout after %s seconds trying to access data store directory %s",
+                              healthcheckTimeout.getSeconds(),
+                              dataStorePath.toString()));
+        } catch (final InterruptedException | ExecutionException e) {
+            healthcheckFuture.cancel(true);
+            LOG.warn("Exception thrown trying to access data store directory {} during healthcheck",
+                     dataStorePath.toString(),
+                     e);
+            return new HealthResult(
+                HealthStatus.UNHEALTHY,
+                String.format("Exception thrown trying to access data store directory %s", dataStorePath.toString()));
+        }
     }
 
     /**

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -247,7 +247,7 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
                 String.format("Timeout after %s seconds trying to access data store directory %s",
                               healthcheckTimeout.getSeconds(),
                               dataStorePath.toString()));
-        } catch (final Exception e) {
+        } catch (final InterruptedException | ExecutionException e) {
             healthcheckFuture.cancel(true);
             LOG.warn("Exception thrown trying to access data store directory {} during healthcheck",
                      dataStorePath.toString(),

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -247,7 +247,7 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
                 String.format("Timeout after %s seconds trying to access data store directory %s",
                               healthcheckTimeout.getSeconds(),
                               dataStorePath.toString()));
-        } catch (final InterruptedException | ExecutionException e) {
+        } catch (final Exception e) {
             healthcheckFuture.cancel(true);
             LOG.warn("Exception thrown trying to access data store directory {} during healthcheck",
                      dataStorePath.toString(),

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -21,6 +21,7 @@ import com.hpe.caf.api.worker.*;
 import org.apache.commons.io.output.ProxyOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStore.java
@@ -394,7 +394,7 @@ public class FileSystemDataStore implements ManagedDataStore, FilePathProvider, 
 
         final Integer configSetting = config.getDataDirHealthcheckTimeoutSeconds();
 
-        return (configSetting == null)
+        return (configSetting == null || configSetting <= 0)
             ? Duration.ofSeconds(DEFAULT_DATA_DIR_HEALTHCHECK_TIMEOUT_SECONDS)
             : Duration.ofSeconds(configSetting);
     }

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreConfiguration.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreConfiguration.java
@@ -31,6 +31,11 @@ public class FileSystemDataStoreConfiguration
     private String dataDir = "datastore";
 
     /**
+     * The data directory healthcheck timeout in seconds.
+     */
+    private Integer dataDirHealthcheckTimeoutSeconds;
+
+    /**
      * The buffer size to use when storing data to the filesystem.
      * <p>
      * Note that not all storage methods currently respect this setting.
@@ -45,6 +50,16 @@ public class FileSystemDataStoreConfiguration
     public void setDataDir(final String dataDir)
     {
         this.dataDir = dataDir;
+    }
+
+    public Integer getDataDirHealthcheckTimeoutSeconds()
+    {
+        return dataDirHealthcheckTimeoutSeconds;
+    }
+
+    public void setDataDirHealthcheckTimeoutSeconds(final Integer dataDirHealthcheckTimeoutSeconds)
+    {
+        this.dataDirHealthcheckTimeoutSeconds = dataDirHealthcheckTimeoutSeconds;
     }
 
     public Integer getOutputBufferSize()

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
@@ -34,9 +34,7 @@ public final class FileSystemDataStoreHealthcheck implements Callable<HealthResu
     @Override
     public HealthResult call() throws IOException
     {
-        // TODO Need FileVisitOption.FOLLOW_SYMBOLIC_LINK option?
-        // try (final DirectoryStream<Path> stream = Files.newDirectoryStream(dataStorePath)) {
-        try (final Stream<Path> stream = Files.walk(dataStorePath, 1)) {
+        try (final Stream<Path> stream = Files.walk(dataStorePath, 0)) {
             return HealthResult.RESULT_HEALTHY;
         }
     }

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
@@ -16,10 +16,11 @@
 package com.hpe.caf.worker.datastore.fs;
 
 import com.hpe.caf.api.HealthResult;
-import com.hpe.caf.api.HealthStatus;
 import java.nio.file.Files;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 
 public final class FileSystemDataStoreHealthcheck implements Callable<HealthResult>
 {
@@ -31,14 +32,12 @@ public final class FileSystemDataStoreHealthcheck implements Callable<HealthResu
     }
 
     @Override
-    public HealthResult call()
+    public HealthResult call() throws IOException
     {
-        if (Files.exists(dataStorePath)) {
+        // TODO Need FileVisitOption.FOLLOW_SYMBOLIC_LINK option?
+        // try (final DirectoryStream<Path> stream = Files.newDirectoryStream(dataStorePath)) {
+        try (final Stream<Path> stream = Files.walk(dataStorePath, 1)) {
             return HealthResult.RESULT_HEALTHY;
-        } else {
-            return new HealthResult(
-                HealthStatus.UNHEALTHY,
-                String.format("Unable to access data store directory: %s", dataStorePath.toString()));
         }
     }
 }

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
@@ -17,7 +17,8 @@ package com.hpe.caf.worker.datastore.fs;
 
 import com.hpe.caf.api.HealthResult;
 import com.hpe.caf.api.HealthStatus;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
 public final class FileSystemDataStoreHealthcheck implements Callable<HealthResult>
@@ -30,7 +31,7 @@ public final class FileSystemDataStoreHealthcheck implements Callable<HealthResu
     }
 
     @Override
-    public HealthResult call() throws Exception
+    public HealthResult call()
     {
         if (Files.exists(dataStorePath)) {
             return HealthResult.RESULT_HEALTHY;

--- a/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
+++ b/worker-store-fs/src/main/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreHealthcheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2020 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.datastore.fs;
+
+import com.hpe.caf.api.HealthResult;
+import com.hpe.caf.api.HealthStatus;
+import java.nio.file.*;
+import java.util.concurrent.Callable;
+
+public final class FileSystemDataStoreHealthcheck implements Callable<HealthResult>
+{
+    private final Path dataStorePath;
+
+    public FileSystemDataStoreHealthcheck(final Path dataStorePath)
+    {
+        this.dataStorePath = dataStorePath;
+    }
+
+    @Override
+    public HealthResult call() throws Exception
+    {
+        if (Files.exists(dataStorePath)) {
+            return HealthResult.RESULT_HEALTHY;
+        } else {
+            return new HealthResult(
+                HealthStatus.UNHEALTHY,
+                String.format("Unable to access data store directory: %s", dataStorePath.toString()));
+        }
+    }
+}

--- a/worker-store-fs/src/test/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreTest.java
+++ b/worker-store-fs/src/test/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreTest.java
@@ -284,9 +284,13 @@ public class FileSystemDataStoreTest
         FileSystemDataStoreHealthcheck healthcheck = new FileSystemDataStoreHealthcheck(nonExistingDataDir);
         healthcheckField.set(store, healthcheck);
 
+        Field dataStorePathField = FileSystemDataStore.class.getDeclaredField("dataStorePath");
+        dataStorePathField.setAccessible(true);
+        dataStorePathField.set(store, nonExistingDataDir);
+
         HealthResult healthResult = store.healthCheck();
         Assert.assertEquals(healthResult.getStatus(), HealthStatus.UNHEALTHY, "Healthcheck status should be UNHEALTHY");
-        Assert.assertEquals(healthResult.getMessage(), "Unable to access data store directory: non-existing-dir",
+        Assert.assertEquals(healthResult.getMessage(), "Exception thrown trying to access data store directory non-existing-dir",
                                                        "Healthcheck message is incorrect");
     }
 

--- a/worker-store-fs/src/test/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreTest.java
+++ b/worker-store-fs/src/test/java/com/hpe/caf/worker/datastore/fs/FileSystemDataStoreTest.java
@@ -49,9 +49,9 @@ import java.util.concurrent.Callable;
 
 public class FileSystemDataStoreTest
 {
+    private static final Integer HEALTHCHECK_TIMEOUT_SECONDS = 10;
     private File temp;
     private final String testData = "test123";
-    private final Integer healthcheckTimeoutSeconds = 10;
 
     @BeforeMethod
     public void setUp()
@@ -138,14 +138,6 @@ public class FileSystemDataStoreTest
         String storeRef = store.store(p, "test");
         verifyStoredData(store, data, storeRef);
         Assert.assertEquals(testData.length(), store.size(storeRef));
-    }
-
-    private FileSystemDataStoreConfiguration createConfig()
-    {
-        FileSystemDataStoreConfiguration conf = new FileSystemDataStoreConfiguration();
-        conf.setDataDir(temp.getAbsolutePath());
-        conf.setDataDirHealthcheckTimeoutSeconds(healthcheckTimeoutSeconds);
-        return conf;
     }
 
     @Test
@@ -320,6 +312,14 @@ public class FileSystemDataStoreTest
         Assert.assertEquals(healthResult.getMessage(),
                             "Timeout after 2 seconds trying to access data store directory " + temp.getAbsolutePath(),
                             "Healthcheck message is incorrect");
+    }
+
+    private FileSystemDataStoreConfiguration createConfig()
+    {
+        FileSystemDataStoreConfiguration conf = new FileSystemDataStoreConfiguration();
+        conf.setDataDir(temp.getAbsolutePath());
+        conf.setDataDirHealthcheckTimeoutSeconds(HEALTHCHECK_TIMEOUT_SECONDS);
+        return conf;
     }
 
     private static void verifyStoredData(final DataStore dataStore, final byte[] expectedData, final String actualReference)


### PR DESCRIPTION
Jira: https://portal.digitalsafe.net/browse/SCMOD-9102

Previously, the worker-store-fs healthcheck always returned HEALTHY. Instead, the healthcheck now checks if the `dataDir` directory exists, and will return UNHEALTHY if `dataDir` does not exist, or is not accessible after a configurable period of time: `CAF_WORKER_DATASTORE_HEALTHCHECK_TIMEOUT_SECONDS`.