### PR TITLE
SCMOD-10661: Implement baseCancel for Queue Consumer

### DIFF
--- a/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/ConsumerCancelEvent.java
+++ b/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/ConsumerCancelEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2020 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.util.rabbitmq;
+
+public class ConsumerCancelEvent implements Event<QueueConsumer>
+{
+    private final String consumerTag;
+
+    public ConsumerCancelEvent(String consumerTag)
+    {
+        this.consumerTag = consumerTag;
+    }
+
+
+    @Override
+    public void handleEvent(final QueueConsumer target)
+    {
+        target.processCancel(consumerTag);
+    }
+}

--- a/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/DefaultRabbitConsumer.java
+++ b/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/DefaultRabbitConsumer.java
@@ -17,6 +17,7 @@ package com.hpe.caf.util.rabbitmq;
 
 import com.rabbitmq.client.Envelope;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
@@ -42,5 +43,12 @@ public class DefaultRabbitConsumer extends RabbitConsumer<QueueConsumer>
     protected final Event<QueueConsumer> getDeliverEvent(Envelope envelope, byte[] data, Map<String, Object> headers)
     {
         return new ConsumerDeliverEvent(new Delivery(envelope, data, headers));
+    }
+
+    @Override
+    public void handleCancel(final String consumerTag) throws IOException
+    {
+        super.handleCancel(consumerTag);
+        getEventQueue().add(new ConsumerCancelEvent(consumerTag));
     }
 }

--- a/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/QueueConsumer.java
+++ b/util-rabbitmq/src/main/java/com/hpe/caf/util/rabbitmq/QueueConsumer.java
@@ -47,4 +47,11 @@ public interface QueueConsumer
      * @param tag the RabbitMQ id of the message to drop
      */
     void processDrop(final long tag);
+
+    /**
+     * Handle cancel request from RabbitMQ broker
+     *
+     * @param consumerTag the tag of the consumer to cancel
+     */
+    void processCancel(final String consumerTag);
 }

--- a/util-rabbitmq/src/test/java/com/hpe/caf/util/rabbitmq/DefaultRabbitConsumerTest.java
+++ b/util-rabbitmq/src/test/java/com/hpe/caf/util/rabbitmq/DefaultRabbitConsumerTest.java
@@ -151,6 +151,12 @@ public class DefaultRabbitConsumerTest
             latch.countDown();
         }
 
+        @Override
+        public void processCancel(String consumerTag)
+        {
+            //no-op
+        }
+
         public Delivery getLastDelivery()
         {
             return lastDelivery;

--- a/worker-api/src/main/java/com/hpe/caf/api/worker/TaskCallback.java
+++ b/worker-api/src/main/java/com/hpe/caf/api/worker/TaskCallback.java
@@ -40,4 +40,10 @@ public interface TaskCallback
      * accepted messages should be considered void.
      */
     void abortTasks();
+
+    /**
+     * Signal that any tasks queued or in operation should be aborted and an error should be reported.
+     * @param errorMsg the error message that caused this abort.
+     */
+    void abortTasksUnhealthy(final String errorMsg);
 }

--- a/worker-queue-rabbit/src/main/java/com/hpe/caf/worker/queue/rabbit/WorkerQueueConsumerImpl.java
+++ b/worker-queue-rabbit/src/main/java/com/hpe/caf/worker/queue/rabbit/WorkerQueueConsumerImpl.java
@@ -126,6 +126,18 @@ public class WorkerQueueConsumerImpl implements QueueConsumer
         processReject(tag, false);
     }
 
+    @Override
+    public void processCancel(final String consumerTag)
+    {
+        try {
+            channel.basicCancel(consumerTag);
+        } catch (final IOException e) {
+            LOG.warn("Failed cancel consumer {} as requested", consumerTag);
+            metrics.incremementErrors();
+        }
+        callback.abortTasksUnhealthy("Consumer " + consumerTag + " received cancel message.");
+    }
+
     /**
      * Process a REJECT event. Similar to ACK, we will requeue the event if it fails, though Lyra should handle most of our failure cases.
      *

--- a/worker-testing-util/src/main/java/com/hpe/caf/worker/testing/QueueServicesFactory.java
+++ b/worker-testing-util/src/main/java/com/hpe/caf/worker/testing/QueueServicesFactory.java
@@ -50,6 +50,11 @@ public class QueueServicesFactory
         public void abortTasks()
         {
         }
+
+        @Override
+        public void abortTasksUnhealthy(final String errorMsg)
+        {
+        }
     }
 
     public static QueueServices create(final RabbitWorkerQueueConfiguration configuration, final String resultsQueueName, final Codec codec)

--- a/worker-testing-util/src/main/java/com/hpe/caf/worker/testing/SimpleQueueConsumerImpl.java
+++ b/worker-testing-util/src/main/java/com/hpe/caf/worker/testing/SimpleQueueConsumerImpl.java
@@ -91,4 +91,9 @@ public class SimpleQueueConsumerImpl implements QueueConsumer
     public void processDrop(long tag)
     {
     }
+
+    @Override
+    public void processCancel(String consumerTag)
+    {
+    }
 }


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-9988

Implements the `basicCancel` method for the RabbitMQ consumers. This is called in the event the broker itself has cancelled the consumer (usually due to the queue being deleted or the node owning the queue going down) which bypasses the `Channel`. See [RabbitMQ docs](https://www.rabbitmq.com/consumer-cancel.html)