### PR TITLE
SCMOD-11585: Attempt to fix random test failure

### DIFF
--- a/worker-queue-rabbit/src/test/java/com/hpe/caf/worker/queue/rabbit/RabbitWorkerQueuePublisherTest.java
+++ b/worker-queue-rabbit/src/test/java/com/hpe/caf/worker/queue/rabbit/RabbitWorkerQueuePublisherTest.java
@@ -64,18 +64,18 @@ public class RabbitWorkerQueuePublisherTest
         BlockingQueue<Event<QueueConsumer>> consumerEvents = new LinkedBlockingQueue<>();
         BlockingQueue<Event<WorkerPublisher>> publisherEvents = new LinkedBlockingQueue<>();
         Channel channel = Mockito.mock(Channel.class);
-        WorkerConfirmListener listener = Mockito.mock(WorkerConfirmListener.class);
-        WorkerPublisher impl = new WorkerPublisherImpl(channel, metrics, consumerEvents, listener);
-        EventPoller<WorkerPublisher> publisher = new EventPoller<>(2, publisherEvents, impl);
-        Thread t = new Thread(publisher);
-        t.start();
-        publisherEvents.add(new WorkerPublishQueueEvent(data, testQueue, taskInformation));
         CountDownLatch latch = new CountDownLatch(1);
         Answer<Void> a = invocationOnMock -> {
             latch.countDown();
             return null;
         };
         Mockito.doAnswer(a).when(channel).basicPublish(Mockito.any(), Mockito.eq(testQueue), Mockito.any(), Mockito.eq(data));
+        WorkerConfirmListener listener = Mockito.mock(WorkerConfirmListener.class);
+        WorkerPublisher impl = new WorkerPublisherImpl(channel, metrics, consumerEvents, listener);
+        EventPoller<WorkerPublisher> publisher = new EventPoller<>(2, publisherEvents, impl);
+        Thread t = new Thread(publisher);
+        t.start();
+        publisherEvents.add(new WorkerPublishQueueEvent(data, testQueue, taskInformation));
         latch.await(5000, TimeUnit.MILLISECONDS);
         publisher.shutdown();
         Assert.assertEquals(0, publisherEvents.size());


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-11585

This test is failing at random (very infrequently) with the below error. 

A previous attempt to fix it over a year ago increased the timeout from 1 second to 5 seconds: 

https://portal.digitalsafe.net/browse/SCMOD-7766

It then started failing again about 6 months ago. At that time an update to the dropwizard dependency fixed it:

https://portal.digitalsafe.net/browse/SCMOD-9048

It failed again a couple of weeks ago. This is an attempt to fix it by setting up the mocks before starting the publisher thread.

```
org.mockito.exceptions.misusing.UnfinishedStubbingException: 

Unfinished stubbing detected here:
-> at com.hpe.caf.worker.queue.rabbit.RabbitWorkerQueuePublisherTest.testHandlePublish(RabbitWorkerQueuePublisherTest.java:78)

E.g. thenReturn() may be missing.
Examples of correct stubbing:
    when(mock.isOk()).thenReturn(true);
    when(mock.isOk())).thenThrow(exception);
    doThrow(exception).when(mock).someVoidMethod();
Hints:
 1. missing thenReturn()
 2. you are trying to stub a final method, which is not supported
 3. you are stubbing the behaviour of another mock inside before 'thenReturn' instruction is completed

	at com.hpe.caf.worker.queue.rabbit.RabbitWorkerQueuePublisherTest.testHandlePublish(RabbitWorkerQueuePublisherTest.java:78
```