### PR TITLE
US616155: Update workers with Queue of Queues rerouting functionality

### DIFF
--- a/official-build.props
+++ b/official-build.props
@@ -1,2 +1,3 @@
 DISABLE_AUTOTAGGING=true
 SEPG_BUILD_ENV_IMAGE=cafapi/opensuse-jdk8-maven:1.0.0
+USE_OPEN_SOURCE_SETTINGS=false

--- a/official-build.props
+++ b/official-build.props
@@ -1,3 +1,2 @@
 DISABLE_AUTOTAGGING=true
 SEPG_BUILD_ENV_IMAGE=cafapi/opensuse-jdk8-maven:1.0.0
-USE_OPEN_SOURCE_SETTINGS=false

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
                 <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
+                <groupId>com.microfocus.apollo</groupId>
+                <artifactId>worker-message-prioritization</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>            
+            <dependency>
                 <groupId>com.rabbitmq</groupId>
                 <artifactId>amqp-client</artifactId>
                 <version>5.8.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                 <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>com.microfocus.apollo</groupId>
+                <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
             </dependency>            

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization-rerouting</artifactId>
-                <version>1.0.0-616155-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>            
             <dependency>
                 <groupId>com.rabbitmq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization-rerouting</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-616155-temp-stooge-test-SNAPSHOT</version>
             </dependency>            
             <dependency>
                 <groupId>com.rabbitmq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization-rerouting</artifactId>
-                <version>1.0.0-616155-temp-stooge-test-SNAPSHOT</version>
+                <version>1.0.0-616155-SNAPSHOT</version>
             </dependency>            
             <dependency>
                 <groupId>com.rabbitmq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
-                <artifactId>worker-message-prioritization</artifactId>
+                <artifactId>worker-message-prioritization-rerouting</artifactId>
                 <version>1.0.0-SNAPSHOT</version>
             </dependency>            
             <dependency>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.workerframework</groupId>
-            <artifactId>worker-message-prioritization</artifactId>
+            <artifactId>worker-message-prioritization-rerouting</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -105,7 +105,7 @@
             <artifactId>worker-tracking-report</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microfocus.apollo</groupId>
+            <groupId>com.github.workerframework</groupId>
             <artifactId>worker-message-prioritization</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -105,6 +105,10 @@
             <artifactId>worker-tracking-report</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.microfocus.apollo</groupId>
+            <artifactId>worker-message-prioritization</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -105,11 +105,6 @@
             <artifactId>worker-tracking-report</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.workerframework</groupId>
-            <artifactId>worker-message-prioritization-rerouting</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
@@ -120,6 +115,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.workerframework</groupId>
+            <artifactId>worker-message-prioritization-rerouting</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -107,6 +107,7 @@
         <dependency>
             <groupId>com.microfocus.apollo</groupId>
             <artifactId>worker-message-prioritization</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=616155

Adding the worker-message-prioritization module so workers can divert message to a staging queue.

Temporarily disable open source settings until wmp repo is relocated to github.com