### PR TITLE
743080: Excessive calls to queueDeclare

### DIFF
--- a/release-notes-6.1.0.md
+++ b/release-notes-6.1.0.md
@@ -5,4 +5,7 @@ ${version-number}
 
 #### New Features
 
+#### Bug Fixes
+- 743080: Excessive calls to queueDeclare have been prevented by recording previously declared queues.
+
 #### Known Issues

--- a/worker-queue-rabbit/src/main/java/com/hpe/caf/worker/queue/rabbit/RabbitWorkerQueue.java
+++ b/worker-queue-rabbit/src/main/java/com/hpe/caf/worker/queue/rabbit/RabbitWorkerQueue.java
@@ -343,6 +343,7 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
         if (!declaredQueues.contains(queueName)) {
 
             RabbitUtil.declareWorkerQueue(channel, queueName, maxPriority);
+            declaredQueues.add(queueName);
         }
     }
 


### PR DESCRIPTION
The Set<> that was used to record queues that had previously been declared was not being populated.
Queues should never be deleted while workers are running, because that would risk losing a message, so this simple cache is acceptable.
