### PR TITLE
I445035: Use dropwizard lifecycle for graceful shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,11 @@
                 <version>3.0.0-549</version>
             </dependency>
             <dependency>
+                <groupId>com.github.cafapi.logging</groupId>
+                <artifactId>caf-logging-logback</artifactId>
+                <version>2.0.0-238</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.cafapi.util</groupId>
                 <artifactId>util-moduleloader</artifactId>
                 <version>3.0.0-549</version>

--- a/release-notes-8.0.0.md
+++ b/release-notes-8.0.0.md
@@ -4,10 +4,13 @@
 ${version-number}
 
 #### New Features
-- **US857114:** Introduced `CAF_RABBITMQ_PROTOCOL` environment variable so that RabbitMQ URL protocol is customisable.
+- **US857114**: Introduced `CAF_RABBITMQ_PROTOCOL` environment variable so that RabbitMQ URL protocol is customisable.
         This allows for TLS-enabled connections to be made to RabbitMQ if desired.
         By default, this variable is set to "amqp" so there is no change in behaviour unless specified. 
 - **US857114:** Quorum queues leveraging 'x-delivery-count' for the handling of poison messages.
+
+#### Bug Fixes
+- **I445035**: Workers now attempt to complete all in-progress and pre-fetched tasks before shutting down.
 
 #### Known Issues
 

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-lifecycle</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
@@ -89,7 +89,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
     public void run(final WorkerConfiguration workerConfiguration, final Environment environment)
         throws QueueException, ModuleLoaderException, CipherException, ConfigurationException, DataStoreException, WorkerException
     {
-        LOG.debug("Worker initializing.");
+        LOG.info("Worker initializing.");
 
         ResponseCache.setDefault(new JobStatusResponseCache());
         BootstrapConfiguration bootstrap = new SystemBootstrapConfiguration();
@@ -113,7 +113,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
         environment.lifecycle().manage(new Managed() {
             @Override
             public void start() {
-                LOG.debug("Worker starting up.");
+                LOG.info("Worker starting up.");
 
                 initCoreMetrics(environment.metrics(), core);
                 initComponentMetrics(environment.metrics(), config, store, core);
@@ -127,7 +127,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
             }
             @Override
             public void stop() {
-                LOG.debug("Worker stop requested, allowing in-progress tasks to complete.");
+                LOG.info("Worker stop requested, allowing in-progress tasks to complete.");
                 workerQueue.shutdownIncoming();
                 while (!wtp.isIdle()) {
                     try {
@@ -136,6 +136,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
                                 wtp.getBacklogSize());
                         Thread.sleep(1000);
                     } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     }
                 }
@@ -151,6 +152,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
                 workerFactory.shutdown();
                 store.shutdown();
                 config.shutdown();
+                LOG.info("Worker stopped.");
             }
         });
     }

--- a/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/hpe/caf/worker/core/WorkerApplication.java
@@ -131,8 +131,9 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
                 workerQueue.shutdownIncoming();
                 while (!wtp.isIdle()) {
                     try {
-                        //TODO Timeout?
-                        LOG.trace("Awaiting the Worker Thread Pool to become idle, {} tasks in the backlog.", wtp.getBacklogSize());
+                        //The grace period will expire and the process killed so no need for time limit here
+                        LOG.trace("Awaiting the Worker Thread Pool to become idle, {} tasks in the backlog.", 
+                                wtp.getBacklogSize());
                         Thread.sleep(1000);
                     } catch (final InterruptedException e) {
                         throw new RuntimeException(e);

--- a/worker-test/pom.xml
+++ b/worker-test/pom.xml
@@ -39,11 +39,6 @@
             <artifactId>caf-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.cafapi.logging</groupId>
-            <artifactId>caf-logging-logback</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.workerframework</groupId>
             <artifactId>worker-api</artifactId>
         </dependency>
@@ -60,6 +55,11 @@
         <dependency>
             <groupId>com.github.cafapi.codec</groupId>
             <artifactId>codec-json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cafapi.logging</groupId>
+            <artifactId>caf-logging-logback</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -271,7 +271,6 @@
                                 </ports>
                                 <env>
                                     <CAF_RABBITMQ_PREFETCH_BUFFER>10</CAF_RABBITMQ_PREFETCH_BUFFER>
-                                    <CAF_LOG_LEVEL>DEBUG</CAF_LOG_LEVEL>
                                     <CAF_WORKER_DATASTORE_PATH>/srv/common/webdav</CAF_WORKER_DATASTORE_PATH>
                                     <CAF_WORKER_JAVA_OPTS>
                                         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005

--- a/worker-test/pom.xml
+++ b/worker-test/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>caf-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.cafapi.logging</groupId>
+            <artifactId>caf-logging-logback</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.workerframework</groupId>
             <artifactId>worker-api</artifactId>
         </dependency>
@@ -265,6 +270,8 @@
                                     <port>${worker.debugport}:5005</port>
                                 </ports>
                                 <env>
+                                    <CAF_RABBITMQ_PREFETCH_BUFFER>10</CAF_RABBITMQ_PREFETCH_BUFFER>
+                                    <CAF_LOG_LEVEL>DEBUG</CAF_LOG_LEVEL>
                                     <CAF_WORKER_DATASTORE_PATH>/srv/common/webdav</CAF_WORKER_DATASTORE_PATH>
                                     <CAF_WORKER_JAVA_OPTS>
                                         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005

--- a/worker-test/src/main/java/com/github/workerframework/testworker/TestWorker.java
+++ b/worker-test/src/main/java/com/github/workerframework/testworker/TestWorker.java
@@ -61,7 +61,7 @@ final class TestWorker implements Worker
 
         if(testWorkerTask.getDelaySeconds() > 0) {
             // Used to test graceful shutdown in the ShutdownDeveloperTest
-            Thread.sleep(testWorkerTask.getDelaySeconds() * 1000);
+            Thread.sleep(testWorkerTask.getDelaySeconds() * 1000L);
         }
         
         return new WorkerResponse(

--- a/worker-test/src/main/java/com/github/workerframework/testworker/TestWorker.java
+++ b/worker-test/src/main/java/com/github/workerframework/testworker/TestWorker.java
@@ -47,8 +47,9 @@ final class TestWorker implements Worker
     public WorkerResponse doWork() throws InterruptedException, TaskRejectedException, InvalidTaskException {
 
         // Required for PoisonMessageIT. If isPoison is true, the worker will exit to simulate a poison message.
+        final TestWorkerTask testWorkerTask;
         try {
-            final TestWorkerTask testWorkerTask = codec.deserialise(workerTask.getData(), TestWorkerTask.class);
+            testWorkerTask = codec.deserialise(workerTask.getData(), TestWorkerTask.class);
             if(testWorkerTask.isPoison()){
                 System.exit(1);
             }
@@ -58,6 +59,11 @@ final class TestWorker implements Worker
 
         final String outputQueue = config.getOutputQueue();
 
+        if(testWorkerTask.getDelaySeconds() > 0) {
+            // Used to test graceful shutdown in the ShutdownDeveloperTest
+            Thread.sleep(testWorkerTask.getDelaySeconds() * 1000);
+        }
+        
         return new WorkerResponse(
             outputQueue,
             TaskStatus.RESULT_SUCCESS,

--- a/worker-test/src/main/java/com/github/workerframework/testworker/TestWorkerTask.java
+++ b/worker-test/src/main/java/com/github/workerframework/testworker/TestWorkerTask.java
@@ -18,11 +18,24 @@ package com.github.workerframework.testworker;
 public class TestWorkerTask {
     private boolean isPoison;
 
+    /**
+     * Configurable delay in processing a message
+     */
+    private int delaySeconds;
+
     public boolean isPoison() {
         return isPoison;
     }
 
     public void setPoison(boolean poison) {
         isPoison = poison;
+    }
+
+    public int getDelaySeconds() {
+        return delaySeconds;
+    }
+
+    public void setDelaySeconds(int delaySeconds) {
+        this.delaySeconds = delaySeconds;
     }
 }

--- a/worker-test/src/test/java/com/hpe/caf/worker/workertest/ShutdownIT.java
+++ b/worker-test/src/test/java/com/hpe/caf/worker/workertest/ShutdownIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2024 Open Text.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.workertest;
+
+import com.github.workerframework.testworker.TestWorkerTask;
+import com.hpe.caf.api.Codec;
+import com.hpe.caf.api.CodecException;
+import com.hpe.caf.api.worker.TaskMessage;
+import com.hpe.caf.api.worker.TaskStatus;
+import com.hpe.caf.codec.JsonCodec;
+import com.hpe.caf.util.rabbitmq.QueueCreator;
+import com.hpe.caf.util.rabbitmq.RabbitHeaders;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+public class ShutdownIT extends TestWorkerTestBase {
+    private static final String POISON_ERROR_MESSAGE = "could not process the item.";
+    private static final String WORKER_FRIENDLY_NAME = "TestWorker";
+    private static final String TEST_WORKER_NAME = "testWorkerIdentifier";
+    private static final String WORKER_IN = "worker-in";
+    private static final String TESTWORKER_OUT = "testworker-out";
+    private static final int TASK_NUMBER = 1;
+    private static final Codec codec = new JsonCodec();
+
+    @Test
+    public void shutdownTest() throws IOException, TimeoutException, CodecException {
+
+        try(final Connection connection = connectionFactory.newConnection()) {
+
+            final Channel channel = connection.createChannel();
+
+            final Map<String, Object> args = new HashMap<>();
+            args.put(QueueCreator.RABBIT_PROP_QUEUE_TYPE, QueueCreator.RABBIT_PROP_QUEUE_TYPE_QUORUM);
+
+            channel.queueDeclare(TESTWORKER_OUT, true, false, false, args);
+            channel.queueDeclare(WORKER_IN, true, false, false, args);
+            
+            final Map<String, Object> retryLimitHeaders = new HashMap<>();
+            retryLimitHeaders.put(RabbitHeaders.RABBIT_HEADER_CAF_WORKER_RETRY_LIMIT, 2);
+//            retryLimitHeaders.put(RabbitHeaders.RABBIT_HEADER_CAF_DELIVERY_COUNT, 2);
+
+            final AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
+                    .headers(retryLimitHeaders)
+                    .contentType("application/json")
+                    .deliveryMode(2)
+                    .build();
+            
+            //Send 100 messages, the test worker will consume 1 every 1 second, from the console send a 
+            // docker stop -t 30 and worker should stop consuming new messages and process what it has pre fetched 
+            for(int index = 0; index < 100; index ++) {
+                final TaskMessage requestTaskMessage = new TaskMessage();
+
+                final TestWorkerTask documentWorkerTask = new TestWorkerTask();
+                documentWorkerTask.setPoison(false);
+                requestTaskMessage.setTaskId(Integer.toString(TASK_NUMBER));
+                requestTaskMessage.setTaskClassifier(TEST_WORKER_NAME);
+                requestTaskMessage.setTaskApiVersion(TASK_NUMBER);
+                requestTaskMessage.setTaskStatus(TaskStatus.NEW_TASK);
+                requestTaskMessage.setTaskData(codec.serialise(documentWorkerTask));
+                requestTaskMessage.setTo(WORKER_IN);
+
+                channel.basicPublish("", WORKER_IN, properties, codec.serialise(requestTaskMessage));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use dropwizard lifecycle for shutdown, worker will be allowed to continue to process pre-fetched messages.