### PR TITLE
1026274: Worker Framework Shutdown hanging

### DIFF
--- a/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
@@ -150,6 +150,11 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
     {
         return workQueue.size() + backupThreadPool.getBacklogSize();
     }
+    
+    @Override 
+    public int getActiveCount() {
+        return backupThreadPool.getActiveCount();
+    }
 
     @Override
     public void submitWorkerTask(final WorkerTaskImpl workerTask)

--- a/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
@@ -37,7 +37,7 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
     private final StreamingWorkerThreadPool backupThreadPool;
 
     private volatile boolean isActive;
-    private volatile AtomicInteger activeThreads = new AtomicInteger(0);
+    private final AtomicInteger activeThreads = new AtomicInteger(0);
 
     public BulkWorkerThreadPool(
         final WorkerFactory workerFactory,
@@ -88,7 +88,7 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
                 = new BulkWorkerTaskProvider(task, workQueue);
 
             try {
-                activeThreads.addAndGet(1);
+                activeThreads.incrementAndGet();
                 bulkWorker.processTasks(taskProvider);
             } catch (final RuntimeException ex) {
                 LOG.warn("Bulk Worker threw unhandled exception", ex);

--- a/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/BulkWorkerThreadPool.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,7 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
     private final StreamingWorkerThreadPool backupThreadPool;
 
     private volatile boolean isActive;
+    private volatile AtomicInteger activeThreads = new AtomicInteger(0);
 
     public BulkWorkerThreadPool(
         final WorkerFactory workerFactory,
@@ -86,10 +88,12 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
                 = new BulkWorkerTaskProvider(task, workQueue);
 
             try {
+                activeThreads.addAndGet(1);
                 bulkWorker.processTasks(taskProvider);
             } catch (final RuntimeException ex) {
                 LOG.warn("Bulk Worker threw unhandled exception", ex);
             } finally {
+                activeThreads.decrementAndGet();
                 // Re-submit the first task if it has not been consumed
                 // NB: It's really faulty Worker logic to not consume at least
                 // the one task.
@@ -152,8 +156,8 @@ final class BulkWorkerThreadPool implements WorkerThreadPool
     }
     
     @Override 
-    public int getActiveCount() {
-        return backupThreadPool.getActiveCount();
+    public int getApproxActiveCount() {
+        return activeThreads.get() + backupThreadPool.getApproxActiveCount();
     }
 
     @Override

--- a/worker-core/src/main/java/com/github/workerframework/core/StreamingWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/StreamingWorkerThreadPool.java
@@ -78,7 +78,7 @@ final class StreamingWorkerThreadPool implements WorkerThreadPool
     }
     
     @Override
-    public int getActiveCount() {
+    public int getApproxActiveCount() {
         return threadPoolExecutor.getActiveCount();
     }
 

--- a/worker-core/src/main/java/com/github/workerframework/core/StreamingWorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/StreamingWorkerThreadPool.java
@@ -76,6 +76,11 @@ final class StreamingWorkerThreadPool implements WorkerThreadPool
     {
         return workQueue.size();
     }
+    
+    @Override
+    public int getActiveCount() {
+        return threadPoolExecutor.getActiveCount();
+    }
 
     /**
      * Execute the specified task at some point in the future

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
@@ -151,10 +151,12 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
 
                 final long startTime = System.currentTimeMillis();
                 
-                while(wtp.getBacklogSize() > 0 && System.currentTimeMillis() - startTime < SHUTDOWN_DURATION) {
+                int backlogSize = wtp.getBacklogSize();
+                while(backlogSize > 0 && System.currentTimeMillis() - startTime < SHUTDOWN_DURATION) {
                     try {
-                        LOG.info("Allowing {} backlog tasks to complete, {} currently active.", wtp.getBacklogSize(), wtp.getApproxActiveCount());
+                        LOG.debug("Allowing {} backlog tasks to complete, {} currently active.", backlogSize, wtp.getApproxActiveCount());
                         Thread.sleep(SHUTDOWN_LOG_INTERVAL);
+                        backlogSize = wtp.getBacklogSize();
                     } catch (final InterruptedException e) {
                         Thread.currentThread().interrupt();
                         break;

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
@@ -78,6 +78,8 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
 {
     private final long startTime = System.currentTimeMillis();
     private static final Logger LOG = LoggerFactory.getLogger(WorkerApplication.class);
+    private static final long SHUTDOWN_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
+    public static final int SHUTDOWN_LOG_INTERVAL = 15_000; // 15 seconds in milliseconds
 
     /**
      * Entry point for the asynchronous micro-service worker framework.
@@ -143,8 +145,22 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
 
             @Override
             public void stop() {
-                LOG.info("Worker stop requested, allowing in-progress tasks to complete.");
+                LOG.info("Worker stop requested.");
+                
                 workerQueue.shutdownIncoming();
+
+                final long startTime = System.currentTimeMillis();
+                
+                while(wtp.getBacklogSize() > 0 && System.currentTimeMillis() - startTime < SHUTDOWN_DURATION) {
+                    try {
+                        LOG.info("Allowing {} backlog tasks to complete, {} currently active.", wtp.getBacklogSize(), wtp.getActiveCount());
+                        Thread.sleep(SHUTDOWN_LOG_INTERVAL); // 15 seconds
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        System.out.println("Logger thread interrupted, exiting...");
+                        break;
+                    }
+                }
                 wtp.shutdown();
                 try {
                     wtp.awaitTermination(5, TimeUnit.MINUTES);

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
@@ -145,23 +145,11 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
             public void stop() {
                 LOG.info("Worker stop requested, allowing in-progress tasks to complete.");
                 workerQueue.shutdownIncoming();
-                while (!wtp.isIdle()) {
-                    try {
-                        //The grace period will expire and the process killed so no need for time limit here
-                        LOG.trace("Awaiting the Worker Thread Pool to become idle, {} tasks in the backlog.", 
-                                wtp.getBacklogSize());
-                        Thread.sleep(1000);
-                    } catch (final InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(e);
-                    }
-                }
-                LOG.trace("Worker Thread Pool is idle.");
                 wtp.shutdown();
                 try {
-                    wtp.awaitTermination(10_000, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    LOG.warn("Shutdown interrupted", e);
+                    wtp.awaitTermination(5, TimeUnit.MINUTES);
+                } catch (final InterruptedException e) {
+                    LOG.error("Worker stop interrupted, in-progress tasks may not have completed.", e);
                     Thread.currentThread().interrupt();
                 }
                 workerQueue.shutdown();

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerApplication.java
@@ -79,7 +79,7 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
     private final long startTime = System.currentTimeMillis();
     private static final Logger LOG = LoggerFactory.getLogger(WorkerApplication.class);
     private static final long SHUTDOWN_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
-    public static final int SHUTDOWN_LOG_INTERVAL = 15_000; // 15 seconds in milliseconds
+    private static final int SHUTDOWN_LOG_INTERVAL = 15_000; // 15 seconds in milliseconds
 
     /**
      * Entry point for the asynchronous micro-service worker framework.
@@ -153,11 +153,10 @@ public final class WorkerApplication extends Application<WorkerConfiguration>
                 
                 while(wtp.getBacklogSize() > 0 && System.currentTimeMillis() - startTime < SHUTDOWN_DURATION) {
                     try {
-                        LOG.info("Allowing {} backlog tasks to complete, {} currently active.", wtp.getBacklogSize(), wtp.getActiveCount());
-                        Thread.sleep(SHUTDOWN_LOG_INTERVAL); // 15 seconds
+                        LOG.info("Allowing {} backlog tasks to complete, {} currently active.", wtp.getBacklogSize(), wtp.getApproxActiveCount());
+                        Thread.sleep(SHUTDOWN_LOG_INTERVAL);
                     } catch (final InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        System.out.println("Logger thread interrupted, exiting...");
                         break;
                     }
                 }

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerThreadPool.java
@@ -62,7 +62,7 @@ interface WorkerThreadPool
 
     int getBacklogSize();
     
-    int getActiveCount();
+    int getApproxActiveCount();
 
     /**
      * Execute the specified task at some point in the future

--- a/worker-core/src/main/java/com/github/workerframework/core/WorkerThreadPool.java
+++ b/worker-core/src/main/java/com/github/workerframework/core/WorkerThreadPool.java
@@ -61,6 +61,8 @@ interface WorkerThreadPool
     boolean isIdle();
 
     int getBacklogSize();
+    
+    int getActiveCount();
 
     /**
      * Execute the specified task at some point in the future

--- a/worker-queue-rabbit/src/main/java/com/github/workerframework/queues/rabbit/RabbitWorkerQueue.java
+++ b/worker-queue-rabbit/src/main/java/com/github/workerframework/queues/rabbit/RabbitWorkerQueue.java
@@ -73,6 +73,7 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
     private final RabbitWorkerQueueConfiguration config;
     private final int maxTasks;
     private static final Logger LOG = LoggerFactory.getLogger(RabbitWorkerQueue.class);
+    private boolean incomingShutdownPermanent = false;
 
     /**
      * Setup a new RabbitWorkerQueue.
@@ -214,6 +215,7 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
      * {@inheritDoc}
      *
      * The incoming queues will all be cancelled so the consumer will fall back to idle.
+     * This is permanent, and attempts to reconnectIncoming will fail.
      */
     @Override
     public void shutdownIncoming()
@@ -224,6 +226,7 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
                 try {
                     incomingChannel.basicCancel(consumerTag);
                     consumerTag = null;
+                    incomingShutdownPermanent = true;
                 } catch (IOException e) {
                     metrics.incremementErrors();
                     LOG.warn("Failed to cancel consumer {}", consumerTag, e);
@@ -277,6 +280,9 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
     public void reconnectIncoming()
     {
         LOG.debug("Reconnecting incoming queues");
+        if(incomingShutdownPermanent) {
+            throw new IllegalStateException("Queue is permanently shutdown");
+        }
         synchronized (consumerLock) {
             if (consumerTag == null && incomingChannel.isOpen()) {
                 try {

--- a/worker-test/src/test/java/com/github/workerframework/workertest/ShutdownDeveloperTest.java
+++ b/worker-test/src/test/java/com/github/workerframework/workertest/ShutdownDeveloperTest.java
@@ -45,7 +45,7 @@ public class ShutdownDeveloperTest extends TestWorkerTestBase {
     public void shutdownTest() throws IOException, TimeoutException, CodecException {
 
         // Usage instructions
-        // Comment out the iages for test worker 2 and 3 in this module's pom.xml
+        // Comment out the images for worker-test-2 and worker-test-no-valid-cert in this module's pom.xml
         // Use mvn docker:start to start test worker
         // Remove the @Ignore and run the test to create 100 test messages
         // From a terminal execute docker stop -t 300 CONTAINER_ID 


### PR DESCRIPTION
Deadlock was caused by the use of System.exit in the test worker, using this opportunity to simplify shutdown logic and use a non-configurable timeout.

Update the shutdownIncoming method to make the shutdown permanent so GatedHealthProvider does not trigger a reconnect.

```
[2025-08-05 13:27:46.140Z #110.028 INFO  -            -   ] c.g.w.core.WorkerApplication: Worker stop requested.
[2025-08-05 13:27:46.145Z #110.028 INFO  -            -   ] c.g.w.core.WorkerApplication: Allowing 10 backlog tasks to complete, 1 currently active.
[2025-08-05 13:28:01.150Z #110.028 INFO  -            -   ] c.g.w.core.WorkerApplication: Allowing 7 backlog tasks to complete, 1 currently active.
...
[2025-08-05 13:28:31.160Z #110.028 INFO  -            -   ] c.g.w.core.WorkerApplication: Allowing 1 backlog tasks to complete, 1 currently active.
[2025-08-05 13:28:46.197Z #110.028 INFO  -            -   ] c.g.w.core.WorkerApplication: Worker stopped.
```

