### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.workerframework</groupId>
     <artifactId>worker-framework-docs</artifactId>
+    <name>worker-framework-docs</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/standard-worker-container/pom.xml
+++ b/standard-worker-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.workerframework</groupId>
     <artifactId>standard-worker-container</artifactId>
+    <name>standard-worker-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/util-rabbitmq/pom.xml
+++ b/util-rabbitmq/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>util-rabbitmq</artifactId>
+    <name>util-rabbitmq</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-api/pom.xml
+++ b/worker-api/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-api</artifactId>
+    <name>worker-api</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-caf/pom.xml
+++ b/worker-caf/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-caf</artifactId>
+    <name>worker-caf</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-configs/pom.xml
+++ b/worker-configs/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-configs</artifactId>
+    <name>worker-configs</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-core</artifactId>
+    <name>worker-core</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-default-configs/pom.xml
+++ b/worker-default-configs/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-default-configs</artifactId>
+    <name>worker-default-configs</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-queue-rabbit/pom.xml
+++ b/worker-queue-rabbit/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-queue-rabbit</artifactId>
+    <name>worker-queue-rabbit</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-store-fs/pom.xml
+++ b/worker-store-fs/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-store-fs</artifactId>
+    <name>worker-store-fs</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-store-http/pom.xml
+++ b/worker-store-http/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-store-http</artifactId>
+    <name>worker-store-http</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-store-mem/pom.xml
+++ b/worker-store-mem/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-store-mem</artifactId>
+    <name>worker-store-mem</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-store-s3/pom.xml
+++ b/worker-store-s3/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-store-s3</artifactId>
+    <name>worker-store-s3</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>

--- a/worker-test/pom.xml
+++ b/worker-test/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-test</artifactId>
+    <name>worker-test</name>
     <properties>
         <targetDockerRegistryPath>devimages</targetDockerRegistryPath>
     </properties>

--- a/worker-tracking-report/pom.xml
+++ b/worker-tracking-report/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-tracking-report</artifactId>
+    <name>worker-tracking-report</name>
     <version>9.1.2-SNAPSHOT</version>
 
     <parent>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210