### PR TITLE
D1054456: Construct an invalid queue name if required

### DIFF
--- a/release-notes-10.0.1.md
+++ b/release-notes-10.0.1.md
@@ -1,8 +1,12 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
+- None
+
+#### Bug Fixes
+- **D1054456:** Corrected invalid queue configuration to be optional  
+  Workers do not have to supply an invalid task queue.
 
 #### Known Issues
+- None

--- a/worker-queue-rabbit/src/main/java/com/github/workerframework/queues/rabbit/RabbitWorkerQueue.java
+++ b/worker-queue-rabbit/src/main/java/com/github/workerframework/queues/rabbit/RabbitWorkerQueue.java
@@ -99,10 +99,25 @@ public final class RabbitWorkerQueue implements ManagedWorkerQueue
     {
         this.config = Objects.requireNonNull(config);
         this.maxTasks = maxTasks;
-        this.invalidQueue = Objects.requireNonNull(invalidQueue);
+        this.invalidQueue = getInvalidQueueName(config, invalidQueue);
         this.dataStore = Objects.requireNonNull(dataStore);
         this.codec = Objects.requireNonNull(codec);
         LOG.debug("Initialised");
+    }
+
+    private static String getInvalidQueueName(final RabbitWorkerQueueConfiguration config, final String invalidQueue)
+    {
+        if (invalidQueue != null) {
+            return invalidQueue;
+        }
+
+        final String inputQueue = config.getInputQueue();
+
+        final String invalidQueuePrefix = inputQueue.endsWith("-in")
+            ? inputQueue.substring(0, inputQueue.length() - 3)
+            : inputQueue;
+
+        return invalidQueuePrefix + "-invalid";
     }
 
     /**


### PR DESCRIPTION
[D1054456 - Worker Framework 10 contains unexpected breaking changes](https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1054456)